### PR TITLE
[JARVIS-111] proper use of <f:password>

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
@@ -211,13 +211,13 @@ public class AdvisorGlobalConfiguration
     return email;
   }
 
-  public @Nonnull String getPassword() {
-    return Secret.toString(password);
+  public @Nonnull Secret getPassword() {
+    return password;
   }
 
   @SuppressWarnings("unused")
-  public void setPassword(@CheckForNull String password) {
-    this.password = Secret.fromString(password);
+  public void setPassword(@CheckForNull Secret password) {
+    this.password = password;
   }
 
   public Set<String> getExcludedComponents() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
@@ -10,6 +10,7 @@ import hudson.model.AsyncPeriodicWork;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.util.IOUtils;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.util.SystemProperties;
 import org.acegisecurity.context.SecurityContext;
@@ -64,7 +65,7 @@ public class BundleUpload extends AsyncPeriodicWork {
 
     Optional<File> bundle = generateBundle();
     if (bundle.isPresent()) {
-      executeInternal(config.getEmail(), config.getPassword(), bundle.get());
+      executeInternal(config.getEmail(), Secret.toString(config.getPassword()), bundle.get());
     } else {
       LOG.warning("Unable to generate support bundle");
     }


### PR DESCRIPTION
This keeps the constructor and getter symmetric.