### PR TITLE
[JARVIS-112] Convert the PageDecorator to an AdminMonitor

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
@@ -3,7 +3,6 @@ package com.cloudbees.jenkins.plugins.advisor;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import jenkins.model.Jenkins;
-import org.jenkinsci.Symbol;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.*;
 
@@ -15,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Displays the reminder that the user needs to register.
  */
-@Extension @Symbol("cloudBeesJenkinsAdvisorReminder")
+@Extension
 public class Reminder extends AdministrativeMonitor {
 
   @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
@@ -35,16 +35,14 @@ public class Reminder extends AdministrativeMonitor {
     }
   }
 
-  public HttpResponse doAct(StaplerRequest request, @QueryParameter(fixEmpty = true) String yes,
+  protected HttpResponse doAct(StaplerRequest request, @QueryParameter(fixEmpty = true) String yes,
                             @QueryParameter(fixEmpty = true) String no) throws IOException, ServletException {
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
     if (yes != null) {
       return HttpResponses.redirectViaContextPath(config.getUrlName());
     } else if (no != null) {
       // should never return null if we get here
-      Jenkins.getInstance().getPluginManager().getPlugin(AdvisorGlobalConfiguration.PLUGIN_NAME).disable();
-      return HttpResponses
-        .redirectViaContextPath(Jenkins.getInstance().getPluginManager().getSearchUrl() + "/installed");
+      return HttpResponses.redirectViaContextPath(Jenkins.getInstance().getPluginManager().getSearchUrl() + "/installed");
     } else { //remind later
       return HttpResponses.forwardToPreviousPage();
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
@@ -5,6 +5,7 @@ import hudson.model.AdministrativeMonitor;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.*;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpSession;
@@ -35,6 +36,7 @@ public class Reminder extends AdministrativeMonitor {
     }
   }
 
+  @RequirePOST
   protected HttpResponse doAct(StaplerRequest request, @QueryParameter(fixEmpty = true) String yes,
                             @QueryParameter(fixEmpty = true) String no) throws IOException, ServletException {
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/Reminder/message.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/Reminder/message.jelly
@@ -3,16 +3,11 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">
-      <j:if test="${h.hasPermission(app.ADMINISTER)}">
-        ${%AdministratorMessage}
-      </j:if>
-      <j:if test="${!h.hasPermission(app.ADMINISTER)}">
-        ${%NonAdministratorMessage}
-      </j:if>
-      <st:nbsp/>
-      <st:nbsp/>
-      <f:submit name="yes" value="${%Connect Now}"/>
-      <f:submit name="no" value="${%Dismiss}"/>
+      <div style="float:right">
+        <f:submit name="yes" value="${%Connect Now}"/>
+        <f:submit name="no" value="${%Uninstall Plugin}"/>
+      </div>
+      ${%Blurb}
     </form>
   </div>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/Reminder/message.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/Reminder/message.properties
@@ -1,2 +1,1 @@
-AdministratorMessage=Get daily reports on security, performance, or stability issues found in your Jenkins master by connecting to CloudBees Jenkins Advisor.
-NonAdministratorMessage=Your administrator has installed CloudBees Jenkins Advisor, but finished the installation. Please contact your admin. 
+Blurb=Get daily reports on security, performance, or stability issues found in your Jenkins master by connecting to CloudBees Jenkins Advisor.


### PR DESCRIPTION
[JARVIS-112](https://cloudbees.atlassian.net/browse/JARVIS-112)

Most admin notifications are now done through the AdminMonitor class, so change the Reminder to register for Jarvis from the PageDecorator class.  I removed the "nag reminder timeout" since other AdminMonitors didn't have one, and now the nag is much less intrusive.  This can always be added back.  I also changed the button text to "Uninstall Plugin" from "Dismiss" because we were doing  redirect.  I could add the "Dismiss" but, I believe it was mentioned earlier, you might as well simply delete the plugin.  Pending review.