### PR TITLE
Fix a wrong URL. Terms-of-service page is Not Found

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/index.jelly
@@ -59,7 +59,7 @@
     	</f:block>
 		<f:entry>
     	    <div>
-				<p>By connecting to CloudBees Jenkins Advisor, you agree to <a href='https://www.cloudbees.com/products/cloudbees-jenkins-advisor/terms-service'>our Terms of Service.</a></p>
+				<p>By connecting to CloudBees Jenkins Advisor, you agree to <a href='https://www.cloudbees.com/jenkins/cloudbees-jenkins-advisor/terms-of-service'>our Terms of Service.</a></p>
     	  <f:submit target='_signup' value="${%Connect account}"/>			</div>
 
    		</f:entry>


### PR DESCRIPTION
The URL pointed to [Terms of Service] by the CloudBees Jenkins Advisor manage page is incorrect.