### PR TITLE
[WIP] See CloudBees Jenkins Advisor reports within Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
       <artifactId>async-http-client</artifactId>
       <version>1.7.24.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.1</version>
+    </dependency>
+
 
     <!-- test dependencies -->
     <dependency>

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
@@ -257,6 +257,10 @@ public class AdvisorGlobalConfiguration
     isValid = valid;
   }
 
+  public AdvisorReports getAdvisorReports() {
+    return Jenkins.getInstance().getExtensionList(AdvisorReports.class).get(0);
+  }
+
   @SuppressWarnings("unused")
   @Extension
   public static final class DescriptorImpl extends Descriptor<AdvisorGlobalConfiguration> {

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
@@ -345,7 +345,6 @@ public class AdvisorGlobalConfiguration
 
     public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
       LOG.log(Level.INFO, "DOES kwhetstone_advisor_webhook exist? "  + AdvisorWebhookCredentialsManager.credentialsExists("kwhetstone_advisor_webhook") );
-      AdvisorWebhookCredentialsManager.listAllCredentials(LOG);
       return AdvisorWebhookCredentialsManager.populateDropdown(credentialsId) ;
     }
   

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
@@ -2,21 +2,26 @@ package com.cloudbees.jenkins.plugins.advisor;
 
 import com.cloudbees.jenkins.plugins.advisor.client.AdvisorClient;
 import com.cloudbees.jenkins.plugins.advisor.client.model.AccountCredentials;
+import com.cloudbees.jenkins.plugins.advisor.webhook.AdvisorWebhookCredentialsManager;
 import com.cloudbees.jenkins.support.SupportAction;
 import com.cloudbees.jenkins.support.SupportPlugin;
 import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import hudson.*;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.model.Descriptor.FormException;
 import hudson.model.ManagementLink;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import jenkins.util.io.OnMaster;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.*;
@@ -53,6 +58,7 @@ public class AdvisorGlobalConfiguration
   private Set<String> excludedComponents;
   private boolean isValid;
   private boolean nagDisabled;
+  private String credentialsId;
 
   @SuppressWarnings("unused")
   public AdvisorGlobalConfiguration() {
@@ -61,10 +67,11 @@ public class AdvisorGlobalConfiguration
 
   @SuppressWarnings("unused")
   @DataBoundConstructor
-  public AdvisorGlobalConfiguration(String email, Secret password, Set<String> excludedComponents) {
+  public AdvisorGlobalConfiguration(String email, Secret password, Set<String> excludedComponents, String credentialsId) {
     this.email = email;
     this.password = password;
     this.excludedComponents = excludedComponents;
+    this.credentialsId = credentialsId;
   }
 
   @CheckForNull
@@ -257,6 +264,14 @@ public class AdvisorGlobalConfiguration
     isValid = valid;
   }
 
+  public void setCredentialsId(String credentialsId) {
+    this.credentialsId = credentialsId;
+  }
+
+  public String getCredentialsId() {
+    return credentialsId;
+  }
+
   public AdvisorReports getAdvisorReports() {
     return Jenkins.getInstance().getExtensionList(AdvisorReports.class).get(0);
   }
@@ -327,6 +342,31 @@ public class AdvisorGlobalConfiguration
         return "" + e.getMessage();
       }
     }
+
+    public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item item, @QueryParameter String credentialsId) {
+      LOG.log(Level.INFO, "DOES kwhetstone_advisor_webhook exist? "  + AdvisorWebhookCredentialsManager.credentialsExists("kwhetstone_advisor_webhook") );
+      AdvisorWebhookCredentialsManager.listAllCredentials(LOG);
+      return AdvisorWebhookCredentialsManager.populateDropdown(credentialsId) ;
+    }
+  
+    //USE THIS TO RUN THE VALIDATION TO INSIGHTS
+    public FormValidation doCheckCredentialsId(@AncestorInPath Item item, @QueryParameter String value) {
+        if (item == null ) {
+          return FormValidation.ok();
+        }
+        if(!item.hasPermission(Item.EXTENDED_READ) && !item.hasPermission(CredentialsProvider.USE_ITEM)) {
+          return FormValidation.ok();
+        }
+  
+        if (StringUtils.isBlank(value)) {
+          return FormValidation.ok();
+        }
+  
+        if (AdvisorWebhookCredentialsManager.credentialsExists(value)) {
+          return FormValidation.error("Cannot find currently selected credentials");
+        }
+        return FormValidation.ok();
+      }
 
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReport.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReport.java
@@ -3,8 +3,7 @@ package com.cloudbees.jenkins.plugins.advisor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * Representation of the results sent by Advisor.
- * 
+ * Representation of the results sent by Advisor
  */
 
 public class AdvisorReport {
@@ -13,23 +12,28 @@ public class AdvisorReport {
     private int performanceCount;
     private int bestPracticeCount;
     private int issueCount;
-    private int percent;
+    private long percent;
+    private long timestamp;
+
 
   public AdvisorReport() {
     this.securityCount = 0;
     this.performanceCount = 0;
     this.bestPracticeCount = 0;
     this.issueCount = 0;
-    this.percent = 100;
+    this.percent = 100L;
+    this.timestamp = System.currentTimeMillis();
   }
 
   @DataBoundConstructor
-  public AdvisorReport(int securityCount, int performanceCount, int bestPracticeCount, int issueCount, int percent) {
+  public AdvisorReport(int securityCount, int performanceCount, int bestPracticeCount, int issueCount, 
+      long percent, long timestamp) {
     this.securityCount = securityCount;
     this.performanceCount = performanceCount;
     this.bestPracticeCount = bestPracticeCount;
     this.issueCount = issueCount;
     this.percent = percent;
+    this.timestamp = timestamp > 0 ? timestamp : System.currentTimeMillis();
   }
 
   public int getSecurityCount() {
@@ -48,8 +52,12 @@ public class AdvisorReport {
     return issueCount;
   }
 
-  public int getPercent() {
+  public long getPercent() {
     return percent;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
   }
     
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReport.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReport.java
@@ -13,7 +13,7 @@ public class AdvisorReport {
     private int bestPracticeCount;
     private int issueCount;
     private long percent;
-    private long timestamp;
+    private long date;
 
 
   public AdvisorReport() {
@@ -22,18 +22,18 @@ public class AdvisorReport {
     this.bestPracticeCount = 0;
     this.issueCount = 0;
     this.percent = 100L;
-    this.timestamp = System.currentTimeMillis();
+    this.date = System.currentTimeMillis();
   }
 
   @DataBoundConstructor
   public AdvisorReport(int securityCount, int performanceCount, int bestPracticeCount, int issueCount, 
-      long percent, long timestamp) {
+    long percent, long date) {
     this.securityCount = securityCount;
     this.performanceCount = performanceCount;
     this.bestPracticeCount = bestPracticeCount;
     this.issueCount = issueCount;
     this.percent = percent;
-    this.timestamp = timestamp > 0 ? timestamp : System.currentTimeMillis();
+    this.date = date > 0 ? date : System.currentTimeMillis();
   }
 
   public int getSecurityCount() {
@@ -56,8 +56,8 @@ public class AdvisorReport {
     return percent;
   }
 
-  public long getTimestamp() {
-    return timestamp;
+  public long getDate() {
+    return date;
   }
-    
+  
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReport.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReport.java
@@ -1,0 +1,55 @@
+package com.cloudbees.jenkins.plugins.advisor;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Representation of the results sent by Advisor.
+ * 
+ */
+
+public class AdvisorReport {
+    
+    private int securityCount;
+    private int performanceCount;
+    private int bestPracticeCount;
+    private int issueCount;
+    private int percent;
+
+  public AdvisorReport() {
+    this.securityCount = 0;
+    this.performanceCount = 0;
+    this.bestPracticeCount = 0;
+    this.issueCount = 0;
+    this.percent = 100;
+  }
+
+  @DataBoundConstructor
+  public AdvisorReport(int securityCount, int performanceCount, int bestPracticeCount, int issueCount, int percent) {
+    this.securityCount = securityCount;
+    this.performanceCount = performanceCount;
+    this.bestPracticeCount = bestPracticeCount;
+    this.issueCount = issueCount;
+    this.percent = percent;
+  }
+
+  public int getSecurityCount() {
+        return securityCount;
+  }
+
+  public int getPerformanceCount() {
+    return performanceCount;
+  }
+    
+  public int getBestPracticeCount() {
+    return bestPracticeCount;
+  }
+
+  public int getIssueCount() {
+    return issueCount;
+  }
+
+  public int getPercent() {
+    return percent;
+  }
+    
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReports.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReports.java
@@ -23,6 +23,9 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,6 +36,7 @@ public class AdvisorReports implements Describable<AdvisorReports>, ExtensionPoi
 
   public static final String ADVISOR_LOC = "advisor-results";
   private final String DIRECTORY = "cloudbees-jenkins-advisor";
+  private final DateFormat DATE_FORMATTER = new SimpleDateFormat("MM/dd/yyyy");
 
   private Queue<AdvisorReport> allReports;
 
@@ -62,6 +66,10 @@ public class AdvisorReports implements Describable<AdvisorReports>, ExtensionPoi
   public void addNewReport(AdvisorReport report) {
     allReports.add(report);
   }
+
+  public String getFormattedTimestamp(long timestamp) {
+    return DATE_FORMATTER.format(new Date(timestamp));
+  } 
 
   /**
    * {@inheritDoc}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReports.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorReports.java
@@ -1,0 +1,126 @@
+package com.cloudbees.jenkins.plugins.advisor;
+
+/**
+ * Results as of the latest Advisor rating.  Used to display information in the UI.
+ * 
+ * Results are saved into $JENKINS_HOME/advisor.
+ */
+
+import hudson.BulkChange;
+import hudson.Extension;
+import hudson.ExtensionPoint;
+import hudson.XmlFile;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Saveable;
+import hudson.model.listeners.SaveableListener;
+import jenkins.model.Jenkins;
+import org.apache.commons.collections4.queue.CircularFifoQueue;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.util.Queue;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
+public class AdvisorReports implements Describable<AdvisorReports>, ExtensionPoint, Saveable {
+  private static final Logger LOG = Logger.getLogger(AdvisorReports.class.getName());
+
+  public static final String ADVISOR_LOC = "advisor-results";
+  private final String DIRECTORY = "cloudbees-jenkins-advisor";
+
+  private Queue<AdvisorReport> allReports;
+
+  @SuppressWarnings("unused")
+  public AdvisorReports() {
+    load();
+    if(allReports == null) {
+      allReports = new CircularFifoQueue<AdvisorReport>(10);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @DataBoundConstructor
+  public AdvisorReports(Queue<AdvisorReport> allReports) {
+    this.allReports = allReports;
+  }
+
+  @CheckForNull
+  public String getUrlName() {
+    return ADVISOR_LOC;
+  }
+
+  public Queue<AdvisorReport> getAllReports() {
+    return allReports;
+  }
+
+  public void addNewReport(AdvisorReport report) {
+    allReports.add(report);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public Descriptor<AdvisorReports> getDescriptor() {
+    return Jenkins.getInstance().getDescriptorOrDie(getClass());
+  }
+
+  @SuppressWarnings("unused")
+  @Extension
+  public static final class DescriptorImpl extends Descriptor<AdvisorReports> {
+
+    public DescriptorImpl() {
+      load();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
+    @Override
+    public String getDisplayName() {
+      return "Advisor Results";
+    }
+  }
+
+
+  /*************** Load Saved Results ***************/
+  @Override
+  public synchronized void save() {
+    if(BulkChange.contains(this))   return;
+    try {
+      getConfigFile().write(this);
+      SaveableListener.fireOnChange(this, getConfigFile());
+    } catch (IOException e) {
+      LOG.log(Level.WARNING, "Failed to save "+getConfigFile(),e);
+    }
+  }
+
+  public synchronized void load() {
+    XmlFile file = getConfigFile();
+    if(!file.exists())
+      return;
+
+    try {
+      file.unmarshal(this);
+    } catch (IOException e) {
+      LOG.log(Level.WARNING, "Failed to load "+file, e);
+    }
+  }
+
+  //work in progress -> will eventually want to change to work as an aggregate save
+  private XmlFile getConfigFile() {
+    return new XmlFile(new File(Jenkins.getInstance().getRootDir()+File.separator+DIRECTORY, getClass().getName()+".xml"));
+  }
+
+  public static AdvisorReports getInstance() {
+    return Jenkins.getInstance().getExtensionList(AdvisorReports.class).get(0);
+  }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientConfig.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientConfig.java
@@ -57,6 +57,10 @@ public class AdvisorClientConfig {
     return advisorURL() + format("/api/users/%s/upload/%s", username, instanceId);
   }
 
+  public static String apiRegisterWebhookURI(String username, String instanceId) {
+    return advisorURL() + format("/api/users/%s/registerWebhook/%s", username, instanceId);
+  }
+
   /**
    * Recursively resolves a property value, taking property substitution into account, and allowing System property
    * overrides to take precedence.

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/model/AdvisorWebhookCredentials.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/model/AdvisorWebhookCredentials.java
@@ -1,0 +1,12 @@
+package com.cloudbees.jenkins.plugins.advisor.client.model;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import hudson.util.Secret;
+
+import java.io.IOException;
+
+public interface AdvisorWebhookCredentials extends StandardCredentials {
+
+    Secret getAdvisorServiceSecret() throws IOException, InterruptedException;
+}
+  

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/model/WebhookUploadRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/model/WebhookUploadRequest.java
@@ -1,0 +1,20 @@
+package com.cloudbees.jenkins.plugins.advisor.client.model;
+
+public class WebhookUploadRequest {
+
+  private final String instanceId;
+  private final String action;
+
+  public WebhookUploadRequest(String instanceId, String action) {
+    this.instanceId = instanceId;
+    this.action = action;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public String getAction() {
+    return action;
+  }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/model/impl/AdvisorWebhookCredentialsImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/client/model/impl/AdvisorWebhookCredentialsImpl.java
@@ -1,0 +1,55 @@
+package com.cloudbees.jenkins.plugins.advisor.client.model.impl;
+
+import com.cloudbees.jenkins.plugins.advisor.client.model.AdvisorWebhookCredentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.Extension;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+
+@SuppressWarnings("unused")
+public class AdvisorWebhookCredentialsImpl extends BaseStandardCredentials implements AdvisorWebhookCredentials {
+
+  @Nonnull
+  private final Secret advisorServiceSecret;
+
+  @DataBoundConstructor
+  public AdvisorWebhookCredentialsImpl(@CheckForNull CredentialsScope scope,
+        @CheckForNull String id, @CheckForNull String description,
+        @CheckForNull String advisorServiceSecret) {
+    super(scope, id, description);
+    this.advisorServiceSecret = Secret.fromString(advisorServiceSecret);
+  }
+
+    
+
+  @Override
+  public Secret getAdvisorServiceSecret() {
+    return advisorServiceSecret;
+  }
+    
+    
+  @Extension
+  public static class DescriptorImpl extends BaseStandardCredentialsDescriptor { 
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDisplayName() {
+        return "CloudBees Jenkins Advisor Webhook Credentials";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIconClassName() {
+        return "cloudbees-jenkins-advisor-credentials";
+    }   
+  }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorCrumbExclusion.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorCrumbExclusion.java
@@ -1,0 +1,43 @@
+package com.cloudbees.jenkins.plugins.advisor.webhook;
+
+/**
+ * Ignore the crumbs since we're posting from an external service.  Check out
+ * https://github.com/jenkinsci/github-plugin/blob/93d40692ff3866705175624e93ec584d4ac88132/src/main/java/com/cloudbees/jenkins/GitHubWebHookCrumbExclusion.java
+ * 
+ * For tests:
+ * https://github.com/jenkinsci/github-plugin/blob/93d40692ff3866705175624e93ec584d4ac88132/src/test/java/com/cloudbees/jenkins/GitHubWebHookCrumbExclusionTest.java
+ */
+
+import hudson.Extension;
+import hudson.security.csrf.CrumbExclusion;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+@Extension
+public class AdvisorCrumbExclusion extends CrumbExclusion {
+
+    @Override
+    public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
+            throws IOException, ServletException {
+        String pathInfo = req.getPathInfo();
+        if (isEmpty(pathInfo)) {
+            return false;
+        }
+        pathInfo = pathInfo.endsWith("/") ? pathInfo : pathInfo + '/';
+        if (!pathInfo.equals(getExclusionPath())) {
+            return false;
+        }
+        chain.doFilter(req, resp);
+        return true;
+    }
+
+    public String getExclusionPath() {
+        return "/" + AdvisorWebhook.URLNAME + "/";
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
@@ -62,12 +62,8 @@ public class AdvisorWebhook implements UnprotectedRootAction {
   @Restricted(NoExternalUse.class)
   public void doIndex(@Nonnull StaplerRequest req) {
     try {
-        LOGGER.info("HIT URL WITH POST");
-        LOGGER.info("params? " + req);
         JSONObject json = req.getSubmittedForm();
-        LOGGER.info("SECURITY COUNT: " + json.getString("securityCount"));
         AdvisorReport newestReport = req.bindJSON(AdvisorReport.class, json);
-        LOGGER.info("SECURITY COUNT from newestReport: " + newestReport.getSecurityCount());
         AdvisorReports reports = AdvisorReports.getInstance();
         reports.addNewReport(newestReport);
         reports.save();

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
@@ -1,0 +1,90 @@
+package com.cloudbees.jenkins.plugins.advisor.webhook;
+
+import com.cloudbees.jenkins.plugins.advisor.AdvisorReport;
+import com.cloudbees.jenkins.plugins.advisor.AdvisorReports;
+import hudson.Extension;
+import hudson.model.RootAction;
+import hudson.model.UnprotectedRootAction;
+import hudson.util.SequentialExecutionQueue;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang3.Validate;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import static hudson.model.Computer.threadPoolForRemoting;
+
+/**
+ * Receives Jenkins hook.
+ *
+ */
+@Extension
+public class AdvisorWebhook implements UnprotectedRootAction {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AdvisorWebhook.class);
+  public static final String URLNAME = "advisor-webhook";
+
+  // headers used for testing the endpoint configuration
+  public static final String URL_VALIDATION_HEADER = "X-Jenkins-Validation";
+  public static final String X_INSTANCE_IDENTITY = "X-Instance-Identity";
+
+  //private final transient SequentialExecutionQueue queue = new SequentialExecutionQueue(threadPoolForRemoting);
+
+  @Override
+  public String getIconFileName() {
+    return null;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return null;
+  }
+
+  @Override
+  public String getUrlName() {
+    return URLNAME;
+  }
+
+
+
+  /**
+   * Receives the webhook call
+   *
+   * @param req  The request
+   */
+  @SuppressWarnings("unused")
+  @RequirePostWithAdvisorPayload
+  @Nonnull
+  @Restricted(NoExternalUse.class)
+  public void doIndex(@Nonnull StaplerRequest req) {
+    try {
+        LOGGER.info("HIT URL WITH POST");
+        LOGGER.info("params? " + req);
+        JSONObject json = req.getSubmittedForm();
+        LOGGER.info("SECURITY COUNT: " + json.getString("securityCount"));
+        AdvisorReport newestReport = req.bindJSON(AdvisorReport.class, json);
+        LOGGER.info("SECURITY COUNT from newestReport: " + newestReport.getSecurityCount());
+        AdvisorReports reports = AdvisorReports.getInstance();
+        reports.addNewReport(newestReport);
+        reports.save();
+    } catch (Exception ex) {
+        LOGGER.error("Exception when processing the current webhooks.", ex);
+    }
+  }
+
+  public static AdvisorWebhook get() {
+    return Jenkins.getInstance().getExtensionList(RootAction.class).get(AdvisorWebhook.class);
+  }
+
+  @Nonnull
+  public static Jenkins getJenkinsInstance() throws IllegalStateException {
+    Jenkins instance = Jenkins.getInstance();
+    Validate.validState(instance != null, "Jenkins has not been started, or was already shut down");
+    return instance;
+  }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
@@ -28,10 +28,6 @@ public class AdvisorWebhook implements UnprotectedRootAction {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdvisorWebhook.class);
   public static final String URLNAME = "advisor-webhook";
 
-  // headers used for testing the endpoint configuration
-  public static final String URL_VALIDATION_HEADER = "X-Jenkins-Validation";
-  public static final String X_INSTANCE_IDENTITY = "X-Instance-Identity";
-
   //private final transient SequentialExecutionQueue queue = new SequentialExecutionQueue(threadPoolForRemoting);
 
   @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhook.java
@@ -5,7 +5,6 @@ import com.cloudbees.jenkins.plugins.advisor.AdvisorReports;
 import hudson.Extension;
 import hudson.model.RootAction;
 import hudson.model.UnprotectedRootAction;
-import hudson.util.SequentialExecutionQueue;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.Validate;
@@ -17,18 +16,16 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
-import static hudson.model.Computer.threadPoolForRemoting;
 
 /**
- * Receives Jenkins hook.
+ * Receives and saves the reports provided by the 
+ * CloudBees Jenkins Advisor hook.
  *
  */
 @Extension
 public class AdvisorWebhook implements UnprotectedRootAction {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdvisorWebhook.class);
   public static final String URLNAME = "advisor-webhook";
-
-  //private final transient SequentialExecutionQueue queue = new SequentialExecutionQueue(threadPoolForRemoting);
 
   @Override
   public String getIconFileName() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhookCredentialsManager.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhookCredentialsManager.java
@@ -1,0 +1,83 @@
+package com.cloudbees.jenkins.plugins.advisor.webhook;
+
+import com.cloudbees.jenkins.plugins.advisor.client.model.AdvisorWebhookCredentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.security.ACL;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import hudson.model.Item;
+import jenkins.model.Jenkins;
+
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import java.util.logging.Logger;
+
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.always;
+
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.filter;
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.withId;
+import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+
+
+public class AdvisorWebhookCredentialsManager {
+
+    public static void listAllCredentials(Logger logger) {
+        List<AdvisorWebhookCredentials> creds = filter(
+            lookupCredentials(AdvisorWebhookCredentials.class, Jenkins.getInstance(), 
+                ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+                always());
+        for(AdvisorWebhookCredentials awc : creds) {
+            logger.info("listAllCredentials getId() " + awc.getId());
+        }
+    }
+
+  public static ListBoxModel populateDropdown(String selectedId) {
+    StandardListBoxModel result = new StandardListBoxModel();
+
+    return result
+      .includeEmptyValue()
+      .includeAs(ACL.SYSTEM, Jenkins.getInstance(), AdvisorWebhookCredentials.class, Collections.<DomainRequirement>emptyList())
+      .includeCurrentValue(selectedId);
+  }
+
+  public static boolean credentialsExists(String idLookup) {
+    List<AdvisorWebhookCredentials> creds = filter(
+        lookupCredentials(AdvisorWebhookCredentials.class, Jenkins.getInstance(), 
+            ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+        withId(trimToEmpty(idLookup))
+      );
+  
+      return !creds.isEmpty();
+  }
+
+  /**
+   * Tries to find the credentials by id and returns secret from it.
+   *
+   * @param credentialsId id to find creds
+   * @return secret from creds or empty optional
+   */
+  @Nonnull
+  public static Secret secretFor(String credentialsId) {
+    List<AdvisorWebhookCredentials> creds = filter(
+      lookupCredentials(AdvisorWebhookCredentials.class, Jenkins.getInstance(),
+          ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+      withId(trimToEmpty(credentialsId))
+    );
+
+    try {
+        if(!creds.isEmpty()) {
+            return creds.get(0).getAdvisorServiceSecret();
+        } else {
+            return null;
+        }
+    } catch (Exception ex) {
+        return null;
+    }
+    
+  }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhookCredentialsManager.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/AdvisorWebhookCredentialsManager.java
@@ -13,9 +13,6 @@ import jenkins.model.Jenkins;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
-import java.util.logging.Logger;
-
-import static com.cloudbees.plugins.credentials.CredentialsMatchers.always;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.filter;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.withId;
@@ -24,16 +21,6 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 
 public class AdvisorWebhookCredentialsManager {
-
-    public static void listAllCredentials(Logger logger) {
-        List<AdvisorWebhookCredentials> creds = filter(
-            lookupCredentials(AdvisorWebhookCredentials.class, Jenkins.getInstance(), 
-                ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
-                always());
-        for(AdvisorWebhookCredentials awc : creds) {
-            logger.info("listAllCredentials getId() " + awc.getId());
-        }
-    }
 
   public static ListBoxModel populateDropdown(String selectedId) {
     StandardListBoxModel result = new StandardListBoxModel();

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/CalculateValidSignature.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/CalculateValidSignature.java
@@ -1,11 +1,13 @@
 package com.cloudbees.jenkins.plugins.advisor.webhook;
 
+import com.cloudbees.jenkins.plugins.advisor.AdvisorGlobalConfiguration;
 import hudson.util.Secret;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Hex;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-
-//https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignature.java
-//https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github/webhook/GHEventPayload.java
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Determines if the given Advisor payload is valid.
@@ -26,21 +28,30 @@ public class CalculateValidSignature {
 
   public static CalculateValidSignature setUp(String fromPost) {
     checkNotNull(fromPost);
-    Secret found = AdvisorWebhookCredentialsManager.secretFor("To get from Webhook");
+    Secret found = AdvisorWebhookCredentialsManager.secretFor(AdvisorGlobalConfiguration.getInstance().getCredentialsId());
     checkNotNull(found);
-    return new CalculateValidSignature(fromPost, found);
+    return new CalculateValidSignature(fromPost.trim(), found);
   }
 
-  public boolean matches() {
+  public boolean matches(String digest) {
     // compute hash
-    String computed = decrypt();
+    String computed = encode().trim();
 
     // String comparison
-    return computed.equals(payload);
+    return computed.equals(digest);
   }
 
-  private String decrypt() {
+  private String encode() {
+    try {
+      final SecretKeySpec keySpec = new SecretKeySpec(Secret.toString(secret).getBytes(UTF_8), HMAC_SHA1_ALGORITHM);
+      final Mac mac = Mac.getInstance(HMAC_SHA1_ALGORITHM);
+      mac.init(keySpec);
+      final byte[] rawHMACBytes = mac.doFinal(payload.getBytes(UTF_8));
+
+      return Hex.encodeHexString(rawHMACBytes);
+    } catch (Exception e) {
       return INVALID_SIGNATURE;
+    }
   }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/CalculateValidSignature.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/CalculateValidSignature.java
@@ -1,0 +1,46 @@
+package com.cloudbees.jenkins.plugins.advisor.webhook;
+
+import hudson.util.Secret;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+//https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github/webhook/GHWebhookSignature.java
+//https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github/webhook/GHEventPayload.java
+
+/**
+ * Determines if the given Advisor payload is valid.
+ */
+
+public class CalculateValidSignature {
+
+  private static final String HMAC_SHA1_ALGORITHM = "HmacSHA1";
+  public static final String INVALID_SIGNATURE = "COMPUTED_INVALID_SIGNATURE";
+
+  private Secret secret;
+  private String payload;
+
+  private CalculateValidSignature(String payload, Secret secret) {
+    this.payload = payload;
+    this.secret = secret;
+  }
+
+  public static CalculateValidSignature setUp(String fromPost) {
+    checkNotNull(fromPost);
+    Secret found = AdvisorWebhookCredentialsManager.secretFor("To get from Webhook");
+    checkNotNull(found);
+    return new CalculateValidSignature(fromPost, found);
+  }
+
+  public boolean matches() {
+    // compute hash
+    String computed = decrypt();
+
+    // String comparison
+    return computed.equals(payload);
+  }
+
+  private String decrypt() {
+      return INVALID_SIGNATURE;
+  }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RegisterWebhookTask.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RegisterWebhookTask.java
@@ -1,0 +1,82 @@
+package com.cloudbees.jenkins.plugins.advisor.webhook;
+
+import com.cloudbees.jenkins.plugins.advisor.AdvisorGlobalConfiguration;
+import com.cloudbees.jenkins.plugins.advisor.AdvisorReports;
+import com.cloudbees.jenkins.plugins.advisor.client.AdvisorClient;
+import com.cloudbees.jenkins.plugins.advisor.client.model.AccountCredentials;
+import com.cloudbees.jenkins.plugins.advisor.client.model.WebhookUploadRequest;
+import com.ning.http.client.ListenableFuture;
+import com.ning.http.client.Response;
+
+import hudson.triggers.SafeTimerTask;
+import hudson.util.Secret;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+
+/**
+ * Called to register or unregister a webhook for this Jenkins instance
+ */
+public class RegisterWebhookTask extends SafeTimerTask {
+
+  public enum ACTION {
+    REGISTER, REMOVE
+  }
+
+  private static final Logger LOG = Logger.getLogger(RegisterWebhookTask.class.getName());
+
+  private final String HEADER = "CloudBees-Advisor-Signature";
+  private ACTION action;
+
+  public RegisterWebhookTask(ACTION action) {
+    this.action = action;
+  }
+
+  protected void doRun() {
+    AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
+    if (config == null) {
+      return;
+    }
+
+    if (!config.isValid()) {
+      LOG.finest("User not registered. Skipping bundle upload.");
+      return;
+    }
+      
+    switch(action) {
+      case REGISTER: registerWebhook(config.getEmail(), Secret.toString(config.getPassword()));
+        break;
+      case REMOVE: removeWebhook();
+        break;
+      default: LOG.info("Nothing to run with the webhook");
+    }
+  }
+
+  private void registerWebhook(String email, String password) {
+    AdvisorClient advisorClient = new AdvisorClient(new AccountCredentials(email, password));
+    ListenableFuture<Response> futureResponse = advisorClient.registerWebhook(new WebhookUploadRequest(Jenkins.getInstance().getLegacyInstanceId(), action.toString()));
+    Response res;
+	try {
+        String credId = AdvisorGlobalConfiguration.getInstance().getCredentialsId();
+        if(credId == null) {
+            res = futureResponse.get();
+            if(res.getStatusCode() == 200) {
+                //AdvisorWebhookCredentialsManager.setSecretFor("credentialsId", res.getHeader(HEADER));
+            }
+        }
+
+	} catch (InterruptedException e) {
+		e.printStackTrace();
+	} catch (ExecutionException e) {
+		e.printStackTrace();
+	}
+    
+  }
+
+  private void removeWebhook() {
+    // build post for client
+    // post simply the request to unregister
+    // delete credential - optional
+  }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RequirePostWithAdvisorPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RequirePostWithAdvisorPayload.java
@@ -1,19 +1,18 @@
 package com.cloudbees.jenkins.plugins.advisor.webhook;
 
-/**
- * REFERENCE: https://github.com/jenkinsci/github-plugin/blob/405e8536e6d8ce00d92e2a9afe4cd4744756d155/src/main/java/org/jenkinsci/plugins/github/webhook/RequirePostWithGHHookPayload.java
- */
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-import java.lang.reflect.InvocationTargetException;
-import javax.servlet.ServletException;
+import com.google.common.base.Optional;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.Interceptor;
 import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
 import org.slf4j.Logger;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.InvocationTargetException;
+import javax.servlet.ServletException;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -29,15 +28,14 @@ import static org.slf4j.LoggerFactory.getLogger;
 public @interface RequirePostWithAdvisorPayload {
   class Processor extends Interceptor {
     private static final Logger LOGGER = getLogger(Processor.class);
-    public static final String SIGNATURE_HEADER = "CloudBees-Advisor-Signature";
+    private static final String SIGNATURE_HEADER = "CloudBees-Advisor-Signature";
 
     @Override
     public Object invoke(StaplerRequest req, StaplerResponse rsp, Object instance, Object[] arguments)
             throws IllegalAccessException, InvocationTargetException, ServletException {
       shouldBePostMethod(req);
-      //returnsInstanceIdentityIfLocalUrlTest(req);
-      //shouldContainParseablePayload(arguments);
-      //shouldProvideValidSignature(req, arguments); //will definitely be revisiting this requirement
+      shouldContainParseablePayload(arguments);
+      shouldProvideValidSignature(req, arguments);
 
       return target.invoke(req, rsp, instance, arguments);
     }
@@ -51,31 +49,44 @@ public @interface RequirePostWithAdvisorPayload {
      * @throws InvocationTargetException if method is not POST
      */
     protected void shouldBePostMethod(StaplerRequest request) throws InvocationTargetException {
-      LOGGER.info("VALUE OF METHOD: " +request.getMethod());
       if (!request.getMethod().equals("POST")) {
         throw new InvocationTargetException(error(SC_METHOD_NOT_ALLOWED, "Method POST required"));
       }
     }
 
     /**
-     * Checks that an incoming request has a valid signature, if there is specified a signature in the config.
+     * Determine if this payload is valid.
+     * 
+     * @param arguments   arguments from payload
+     */
+    private void shouldContainParseablePayload(Object[] arguments) {
+      for(int x=0; x< arguments.length; x++ ) {
+        LOGGER.info("VALUE OF ARGS: " + arguments[x]);
+      }
+    }
+
+    /**
+     * Checks that an incoming request has a valid signature.
      *
      * @param req Incoming request.
-     *
      * @throws InvocationTargetException if any of preconditions is not satisfied
      */
-    /*protected void shouldProvideValidSignature(StaplerRequest req, Object[] args) throws InvocationTargetException {
+    protected void shouldProvideValidSignature(StaplerRequest req, Object[] args) throws InvocationTargetException {
       Optional<String> signHeader = Optional.fromNullable(req.getHeader(SIGNATURE_HEADER));
-      Secret secret = GitHubPlugin.configuration().getHookSecretConfig().getHookSecret();
+      
+      //Secret secret = GitHubPlugin.configuration().getHookSecretConfig().getHookSecret();
 
-      if (signHeader.isPresent() && Optional.fromNullable(secret).isPresent()) {
-        String digest = substringAfter(signHeader.get(), SHA1_PREFIX);
+      if (signHeader.isPresent()){ //&& Optional.fromNullable(secret).isPresent()) {
+        LOGGER.info("SIGNED HEADER: " + signHeader.get());
+        /*String digest = substringAfter(signHeader.get(), SHA1_PREFIX);
         LOGGER.trace("Trying to verify sign from header {}", signHeader.get());
         isTrue(
                 GHWebhookSignature.webhookSignature(payloadFrom(req, args), secret).matches(digest),
                 String.format("Provided signature [%s] did not match to calculated", digest)
-        );
+        );*/
+      } else {
+          LOGGER.info("Apparently it was null");
       }
-    }*/
+    }
   }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RequirePostWithAdvisorPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RequirePostWithAdvisorPayload.java
@@ -1,0 +1,81 @@
+package com.cloudbees.jenkins.plugins.advisor.webhook;
+
+/**
+ * REFERENCE: https://github.com/jenkinsci/github-plugin/blob/405e8536e6d8ce00d92e2a9afe4cd4744756d155/src/main/java/org/jenkinsci/plugins/github/webhook/RequirePostWithGHHookPayload.java
+ */
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.InvocationTargetException;
+import javax.servlet.ServletException;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.Interceptor;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.slf4j.Logger;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static javax.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
+import static org.kohsuke.stapler.HttpResponses.error;
+import static org.kohsuke.stapler.HttpResponses.errorWithoutStack;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Retention(RUNTIME)
+@Target({METHOD, FIELD})
+@InterceptorAnnotation(RequirePostWithAdvisorPayload.Processor.class)
+public @interface RequirePostWithAdvisorPayload {
+  class Processor extends Interceptor {
+    private static final Logger LOGGER = getLogger(Processor.class);
+    public static final String SIGNATURE_HEADER = "CloudBees-Advisor-Signature";
+
+    @Override
+    public Object invoke(StaplerRequest req, StaplerResponse rsp, Object instance, Object[] arguments)
+            throws IllegalAccessException, InvocationTargetException, ServletException {
+      shouldBePostMethod(req);
+      //returnsInstanceIdentityIfLocalUrlTest(req);
+      //shouldContainParseablePayload(arguments);
+      //shouldProvideValidSignature(req, arguments); //will definitely be revisiting this requirement
+
+      return target.invoke(req, rsp, instance, arguments);
+    }
+
+    /**
+     * Duplicates org.kohsuke.stapler.interceptor.RequirePOST precheck.
+     * As of it can't guarantee order of multiply interceptor calls,
+     * it should implement all features of required interceptors in one class
+     *
+     * @param request what should be a post
+     * @throws InvocationTargetException if method is not POST
+     */
+    protected void shouldBePostMethod(StaplerRequest request) throws InvocationTargetException {
+      LOGGER.info("VALUE OF METHOD: " +request.getMethod());
+      if (!request.getMethod().equals("POST")) {
+        throw new InvocationTargetException(error(SC_METHOD_NOT_ALLOWED, "Method POST required"));
+      }
+    }
+
+    /**
+     * Checks that an incoming request has a valid signature, if there is specified a signature in the config.
+     *
+     * @param req Incoming request.
+     *
+     * @throws InvocationTargetException if any of preconditions is not satisfied
+     */
+    /*protected void shouldProvideValidSignature(StaplerRequest req, Object[] args) throws InvocationTargetException {
+      Optional<String> signHeader = Optional.fromNullable(req.getHeader(SIGNATURE_HEADER));
+      Secret secret = GitHubPlugin.configuration().getHookSecretConfig().getHookSecret();
+
+      if (signHeader.isPresent() && Optional.fromNullable(secret).isPresent()) {
+        String digest = substringAfter(signHeader.get(), SHA1_PREFIX);
+        LOGGER.trace("Trying to verify sign from header {}", signHeader.get());
+        isTrue(
+                GHWebhookSignature.webhookSignature(payloadFrom(req, args), secret).matches(digest),
+                String.format("Provided signature [%s] did not match to calculated", digest)
+        );
+      }
+    }*/
+  }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RequirePostWithAdvisorPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/webhook/RequirePostWithAdvisorPayload.java
@@ -18,6 +18,7 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static javax.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static org.kohsuke.stapler.HttpResponses.error;
 import static org.kohsuke.stapler.HttpResponses.errorWithoutStack;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -62,6 +63,8 @@ public @interface RequirePostWithAdvisorPayload {
     private void shouldContainParseablePayload(Object[] arguments) {
       for(int x=0; x< arguments.length; x++ ) {
         LOGGER.info("VALUE OF ARGS: " + arguments[x]);
+        //isTrue should be called here
+        //also check if the payload is null
       }
     }
 
@@ -81,12 +84,26 @@ public @interface RequirePostWithAdvisorPayload {
         /*String digest = substringAfter(signHeader.get(), SHA1_PREFIX);
         LOGGER.trace("Trying to verify sign from header {}", signHeader.get());
         isTrue(
-                GHWebhookSignature.webhookSignature(payloadFrom(req, args), secret).matches(digest),
+                CalculateValidSignature.setUp(payloadFrom(req, args), secret).matches(digest),
                 String.format("Provided signature [%s] did not match to calculated", digest)
         );*/
       } else {
           LOGGER.info("Apparently it was null");
       }
     }
+
+            /**
+         * Utility method to stop preprocessing if condition is false
+         *
+         * @param condition on false throws exception
+         * @param msg       to add to exception
+         *
+         * @throws InvocationTargetException BAD REQUEST 400 status code with message
+         */
+        private void isTrue(boolean condition, String msg) throws InvocationTargetException {
+          if (!condition) {
+              throw new InvocationTargetException(errorWithoutStack(SC_BAD_REQUEST, msg));
+          }
+}
   }
 }

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/help-credentialsId.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/help-credentialsId.html
@@ -1,0 +1,4 @@
+<div>
+    <p>If you would like to receive summary reports within Jenkins, you must select a valid webhook credentials.</p>
+    <p>Please choose the credentials that are paired with the account you are using to connect to CloudBees Jenkins Advisor.</p>
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/index.jelly
@@ -7,6 +7,9 @@
       <h1>
         ${it.actionTitle}
       </h1>
+    <div align="left">
+       <a href='./reports'>See recent CloudBees Jenkins Advisor reports for this instance. --></a>
+    </div>
 		<div>
 		<p>Get free, daily reports on your Jenkins master's health by connecting your Jenkins instance to CloudBees Jenkins advisor.</p>
 		<p>To get started, sign in with your CloudBees Network account. Don't have an account? <a href='https://cloudbees.com/activate-cloudbees-jenkins-advisor' target='_signup'>Create one now.</a></p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/index.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
-         xmlns:f="/lib/form" xmlns:a="/lib/advisor">
+         xmlns:f="/lib/form" xmlns:a="/lib/advisor" xmlns:c="/lib/credentials">
   <l:layout title="${it.actionTitleText}" norefresh="true" permission="${it.ADMINISTRATOR}">
     <st:include page="sidepanel.jelly" it="${app}"/>
     <l:main-panel>
@@ -27,7 +27,10 @@
         </f:entry>
         <f:validateButton
           title="${%Test Connection}" progress="${%Testing...}"
-          method="testConnection" with="email,password" />       
+          method="testConnection" with="email,password" />
+        <f:entry field="credentialsId" title="${%Advisor Webhook Credentials}">
+          <c:select/>
+        </f:entry>       
         <f:block>
         	<table style="text-align:left">
             <f:section name="advanced" title="Configure data">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
@@ -1,0 +1,28 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
+         xmlns:f="/lib/form" xmlns:a="/lib/advisor">
+    <l:layout title="Advisor Reports" norefresh="true" permission="${it.ADMINISTRATOR}">
+    <st:include page="sidepanel.jelly" it="${app}"/>
+    <l:main-panel>
+        <div align="left">
+           <a href='.'>Back to CloudBees Jenkins Advisor configuration.</a>
+        </div>
+        <p>Current results for the provided Advisor report</p>
+        <j:set var="reports" value="${it.advisorReports}"/>
+        <j:if test="${reports.isEmpty}">
+            No reports are available within Jenkins at this time.  Please check your email for reports available before plugin update/install.
+        </j:if>
+        <j:forEach var="report" items="${reports.allReports}">
+            <f:entry field="report">
+            <ul>
+                <li>Security: ${report.securityCount}</li>
+                <li>Performance: ${report.performanceCount}</li>
+                <li>Best Practice: ${report.bestPracticeCount}</li>
+                <li>Stability: ${report.issueCount}</li>
+            </ul>
+            </f:entry>
+            <br />
+        </j:forEach>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
@@ -9,12 +9,14 @@
         </div>
         <p>Current results for the provided Advisor report</p>
         <j:set var="reports" value="${it.advisorReports}"/>
-        <j:if test="${reports.isEmpty}">
+        <j:if test="${reports.allReports.isEmpty()}">
             No reports are available within Jenkins at this time.  Please check your email for reports available before plugin update/install.
         </j:if>
         <j:forEach var="report" items="${reports.allReports}">
             <f:entry field="report">
+            
             <ul>
+                <lh>${reports.getFormattedTimestamp(report.timestamp)}</lh>
                 <li>Security: ${report.securityCount}</li>
                 <li>Performance: ${report.performanceCount}</li>
                 <li>Best Practice: ${report.bestPracticeCount}</li>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
@@ -16,7 +16,7 @@
             <f:entry field="report">
             
             <ul>
-                <lh>${reports.getFormattedTimestamp(report.timestamp)}</lh>
+                <lh>${reports.getFormattedTimestamp(report.date)}</lh>
                 <li>Security: ${report.securityCount}</li>
                 <li>Performance: ${report.performanceCount}</li>
                 <li>Best Practice: ${report.bestPracticeCount}</li>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration/reports.jelly
@@ -7,7 +7,7 @@
         <div align="left">
            <a href='.'>Back to CloudBees Jenkins Advisor configuration.</a>
         </div>
-        <p>Current results for the provided Advisor report</p>
+        <h1>Current results for the provided Advisor report</h1>
         <j:set var="reports" value="${it.advisorReports}"/>
         <j:if test="${reports.allReports.isEmpty()}">
             No reports are available within Jenkins at this time.  Please check your email for reports available before plugin update/install.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/client/model/impl/AdvisorWebhookCredentialsImpl/credentials.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/client/model/impl/AdvisorWebhookCredentialsImpl/credentials.jelly
@@ -1,0 +1,9 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <!--<f:entry title="${%Username}" field="username">
+    <f:textbox/>
+  </f:entry>-->
+  <f:entry title="${%Advisor Webhook Secret}" field="advisorServiceSecret">
+    <f:password/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/advisor/client/model/impl/AdvisorWebhookCredentialsImpl/help-advisorServiceSecret.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/advisor/client/model/impl/AdvisorWebhookCredentialsImpl/help-advisorServiceSecret.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    The token returned from CloudBees Jenkins Advisor when requesting a webhook.
+  </p>
+</div>


### PR DESCRIPTION
A common request is to have more information about the Advisor reports in the UI itself.   This PR sets up a webhook that can receive info from the CloudBees Jenkins Advisor service, and display it within the UI.  Right now, this will receive, store, and display the information on the UI.  It's rudimentary right now, but this partially is out there to get a feel if this is as widespread as my impression was.

To use: you need to create `CloudBees Jenkins Advisor Credential` with a valid key from insights (automation coming soon).  After that, the plugin handles everything else.  Access the list of reports from the "Configure CloudBees Jenkins Advisor" page.

It's pretty rough right now, and there are a few things that need to be done if this is really the direction we want to go:
- [ ]  Credentials situation fully automated
- [ ]  Better display of issues
- [ ]  Tests (so, so many tests)
- [ ]  Documentation!