### PR TITLE
Add release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+tag-template: cloudbees-jenkins-advisor-$NEXT_MINOR_VERSION


### PR DESCRIPTION
This adds release-drafter to the repo to automatically set up release notes.  There's more about it in the [jenkinsci/.github](https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc) repo.