### PR TITLE
[JENKINS-59695] Add JCasC compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <java.level>8</java.level>
     <hpi.pluginChagelogUrl>https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/releases</hpi.pluginChagelogUrl>
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/cloudbees-jenkins-advisor-plugin/master/src/main/webapp/icons/advisor.svg</hpi.pluginLogoUrl>
-    <jcasc.version>1.30</jcasc.version>
   </properties>
 
   <name>Jenkins Health Advisor by CloudBees Plugin</name>
@@ -92,7 +91,6 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${jcasc.version}</version>
       <optional>true</optional>
     </dependency>
 
@@ -100,7 +98,6 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${jcasc.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <java.level>8</java.level>
     <hpi.pluginChagelogUrl>https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/releases</hpi.pluginChagelogUrl>
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/cloudbees-jenkins-advisor-plugin/master/src/main/webapp/icons/advisor.svg</hpi.pluginLogoUrl>
+    <jcasc.version>1.30</jcasc.version>
   </properties>
 
   <name>Jenkins Health Advisor by CloudBees Plugin</name>
@@ -88,8 +89,21 @@
       <artifactId>support-core</artifactId>
       <version>2.62</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <optional>true</optional>
+    </dependency>
 
     <!-- test dependencies -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
@@ -53,6 +53,7 @@ public class AdvisorGlobalConfiguration
   implements Describable<AdvisorGlobalConfiguration>, ExtensionPoint, Saveable, OnMaster {
 
   public static final String PLUGIN_NAME = "cloudbees-jenkins-advisor";
+  public static final String SEND_ALL_COMPONENTS = "SENDALL";
 
   private static final Logger LOG = Logger.getLogger(AdvisorGlobalConfiguration.class.getName());
 
@@ -415,7 +416,7 @@ public class AdvisorGlobalConfiguration
       }
       // Note that we're not excluding anything
       if(remove.isEmpty()) {
-        remove.add("SENDALL");
+        remove.add(SEND_ALL_COMPONENTS);
       }
 
       final AdvisorGlobalConfiguration insights = AdvisorGlobalConfiguration.getInstance();

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
@@ -36,7 +36,7 @@ public class AdvisorRootConfigurator extends BaseConfigurator<AdvisorGlobalConfi
     private static final Logger LOG = Logger.getLogger(AdvisorRootConfigurator.class.getName());
 
     // Ignoring lastBundleResult since it is not configured in the plugin. It only informs about the last bundle generation
-    // Ignoring isValid since it is something auto-acalculated during the configuration
+    // Ignoring isValid since it is something auto-calculated during the configuration
     private final Collection<String> excludedAttributesInConf = Arrays.asList("lastBundleResult", "valid");
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
@@ -80,6 +80,11 @@ public class AdvisorRootConfigurator extends BaseConfigurator<AdvisorGlobalConfi
         }
 
         // Check and apply configuration
+        if (!acceptToS) {
+            // In UI, if you don't accept the ToS, the configuration is not applied, so here we throw an exception
+            throw new ConfiguratorException(this, "Terms of Service for CloudBees Jenkins Advisor have to be accepted. Please, review the acceptToS field in the yaml file.");
+        }
+
         AdvisorGlobalConfiguration insights = getTargetComponent(configurationContext);
         AdvisorGlobalConfiguration.DescriptorImpl descriptor = (AdvisorGlobalConfiguration.DescriptorImpl) insights.getDescriptor();
         boolean valid = true;
@@ -87,12 +92,7 @@ public class AdvisorRootConfigurator extends BaseConfigurator<AdvisorGlobalConfi
             valid = false;
         }
         if (valid) {
-            if (acceptToS) {
-                updateConfiguration(insights, email, cc, true, nagDisabled, excludedComponents);
-            } else {
-                // In UI, if you don't accept the ToS, the configuration is not applied, so here we throw an exception
-                throw new ConfiguratorException(this, "Terms of Service for CloudBees Jenkins Advisor have to be accepted. Please, review the acceptToS field in the yaml file.");
-            }
+            updateConfiguration(insights, email, cc, true, nagDisabled, excludedComponents);
         } else {
             // In UI, if the fields are invalid, the configuration is not applied, so here we throw an exception
             throw new ConfiguratorException(this, "Invalid configuration for CloudBees Jenkins Advisor. Please, review the content of email and cc fields in the yaml file.");

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
@@ -1,0 +1,151 @@
+package com.cloudbees.jenkins.plugins.advisor.casc;
+
+import com.cloudbees.jenkins.plugins.advisor.AdvisorGlobalConfiguration;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.FormValidation;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Scalar;
+import io.jenkins.plugins.casc.model.Sequence;
+import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * A root element configurator used for configuring CloudBees Jenkins Advisor through {@link io.jenkins.plugins.casc.ConfigurationAsCode}
+ * https://github.com/jenkinsci/configuration-as-code-plugin
+ */
+@Extension(optional = true)
+@Restricted(NoExternalUse.class)
+public class AdvisorRootConfigurator extends BaseConfigurator<AdvisorGlobalConfiguration> implements RootElementConfigurator<AdvisorGlobalConfiguration> {
+
+    private static final Logger LOG = Logger.getLogger(AdvisorRootConfigurator.class.getName());
+
+    // Ignoring lastBundleResult since it is not configured in the plugin. It only informs about the last bundle generation
+    // Ignoring isValid since it is something auto-acalculated during the configuration
+    private final Collection<String> excludedAttributesInConf = Arrays.asList("lastBundleResult", "valid");
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "advisor";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return getConfiguration().getDisplayName();
+    }
+
+    @Override
+    protected AdvisorGlobalConfiguration instance(Mapping mapping, ConfigurationContext configurationContext) throws ConfiguratorException {
+        // Scalar values
+        final String email = (mapping.get("email") != null ? mapping.getScalarValue("email") : StringUtils.EMPTY);
+        final String cc = (mapping.get("cc") != null ? mapping.getScalarValue("cc") : StringUtils.EMPTY);
+        final boolean nagDisabled = (mapping.get("nagDisabled") != null ? BooleanUtils.toBoolean(mapping.getScalarValue("nagDisabled")) : false);
+        final boolean acceptToS = (mapping.get("acceptToS") != null ? BooleanUtils.toBoolean(mapping.getScalarValue("acceptToS")) : false);
+
+        // List values
+        final Set<String> excludedComponents = new HashSet<>();
+        CNode excludedCN = mapping.get("excludedComponents");
+        if (excludedCN != null) {
+            if (excludedCN instanceof Sequence) {
+                Sequence s = (Sequence) excludedCN;
+                for (CNode cNode : s) {
+                    excludedComponents.add(cNode.asScalar().getValue());
+                }
+
+                if (excludedComponents.isEmpty()) {
+                    excludedComponents.add(AdvisorGlobalConfiguration.SEND_ALL_COMPONENTS);
+                }
+            } else {
+                throw new ConfiguratorException(this, "Excluded components are expected to be a collection.");
+            }
+
+        } else {
+            excludedComponents.add(AdvisorGlobalConfiguration.SEND_ALL_COMPONENTS);
+        }
+
+        // Check and apply configuration
+        AdvisorGlobalConfiguration insights = getTargetComponent(configurationContext);
+        AdvisorGlobalConfiguration.DescriptorImpl descriptor = (AdvisorGlobalConfiguration.DescriptorImpl) insights.getDescriptor();
+        boolean valid = true;
+        if (descriptor.doCheckEmail(email).kind.equals(FormValidation.Kind.ERROR) || descriptor.doCheckCc(cc).kind.equals(FormValidation.Kind.ERROR)) {
+            valid = false;
+        }
+        if (valid) {
+            if (acceptToS) {
+                updateConfiguration(insights, email, cc, true, nagDisabled, excludedComponents);
+            } else {
+                // In UI, if you don't accept the ToS, the configuration is not applied, so here we throw an exception
+                throw new ConfiguratorException(this, "Terms of Service for CloudBees Jenkins Advisor have to be accepted. Please, review the yaml file.");
+            }
+        } else {
+            // In UI, if the fields are invalid, the configuration is not applied, so here we throw an exception
+            throw new ConfiguratorException(this, "Invalid configuration for CloudBees Jenkins Advisor. Please, review the content of email and cc fields in the yaml file.");
+        }
+        return insights;
+    }
+
+    private void updateConfiguration(AdvisorGlobalConfiguration conf, String email, String cc, boolean acceptToS, boolean nagDisabled, Set<String> excludedComponents) {
+        conf.setEmail(email);
+        conf.setCc(cc);
+        conf.setAcceptToS(acceptToS);
+        conf.setNagDisabled(nagDisabled);
+        conf.setExcludedComponents(excludedComponents);
+        conf.setValid(true);
+    }
+
+    @Override
+    public AdvisorGlobalConfiguration getTargetComponent(ConfigurationContext configurationContext) {
+        return getConfiguration();
+    }
+
+    @Override
+    public Class<AdvisorGlobalConfiguration> getTarget() {
+        return AdvisorGlobalConfiguration.class;
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(AdvisorGlobalConfiguration instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        // In UI, email is mandatory. If the email is empty, the Advisor is not configured, so nothing should be exported
+        if (StringUtils.isNotBlank(instance.getEmail())) {
+            for (Attribute attribute : describe()) {
+                final String attributeName = attribute.getName();
+                if (!excludedAttributesInConf.contains(attributeName)) {
+                    mapping.put(attributeName, attribute.describe(instance, context));
+                }
+            }
+
+            CNode excluded = mapping.get("excludedComponents");
+            if (excluded instanceof Sequence) {
+                Sequence seq = (Sequence) excluded;
+                if (seq.isEmpty()) {
+                    seq.add(new Scalar(AdvisorGlobalConfiguration.SEND_ALL_COMPONENTS));
+                }
+            }
+        }
+
+        return mapping;
+    }
+
+    private AdvisorGlobalConfiguration getConfiguration() {
+        AdvisorGlobalConfiguration current = AdvisorGlobalConfiguration.getInstance();
+        return current != null ? current : new AdvisorGlobalConfiguration();
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
@@ -72,7 +72,7 @@ public class AdvisorRootConfigurator extends BaseConfigurator<AdvisorGlobalConfi
                     excludedComponents.add(AdvisorGlobalConfiguration.SEND_ALL_COMPONENTS);
                 }
             } else {
-                throw new ConfiguratorException(this, "Excluded components are expected to be a collection.");
+                throw new ConfiguratorException(this, "Excluded components are expected to be a list.");
             }
 
         } else {
@@ -91,7 +91,7 @@ public class AdvisorRootConfigurator extends BaseConfigurator<AdvisorGlobalConfi
                 updateConfiguration(insights, email, cc, true, nagDisabled, excludedComponents);
             } else {
                 // In UI, if you don't accept the ToS, the configuration is not applied, so here we throw an exception
-                throw new ConfiguratorException(this, "Terms of Service for CloudBees Jenkins Advisor have to be accepted. Please, review the yaml file.");
+                throw new ConfiguratorException(this, "Terms of Service for CloudBees Jenkins Advisor have to be accepted. Please, review the acceptToS field in the yaml file.");
             }
         } else {
             // In UI, if the fields are invalid, the configuration is not applied, so here we throw an exception

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfigurator.java
@@ -87,16 +87,12 @@ public class AdvisorRootConfigurator extends BaseConfigurator<AdvisorGlobalConfi
 
         AdvisorGlobalConfiguration insights = getTargetComponent(configurationContext);
         AdvisorGlobalConfiguration.DescriptorImpl descriptor = (AdvisorGlobalConfiguration.DescriptorImpl) insights.getDescriptor();
-        boolean valid = true;
         if (descriptor.doCheckEmail(email).kind.equals(FormValidation.Kind.ERROR) || descriptor.doCheckCc(cc).kind.equals(FormValidation.Kind.ERROR)) {
-            valid = false;
-        }
-        if (valid) {
-            updateConfiguration(insights, email, cc, true, nagDisabled, excludedComponents);
-        } else {
             // In UI, if the fields are invalid, the configuration is not applied, so here we throw an exception
             throw new ConfiguratorException(this, "Invalid configuration for CloudBees Jenkins Advisor. Please, review the content of email and cc fields in the yaml file.");
         }
+        updateConfiguration(insights, email, cc, true, nagDisabled, excludedComponents);
+
         return insights;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorJCasCompatibilityTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorJCasCompatibilityTest.java
@@ -1,0 +1,30 @@
+package com.cloudbees.jenkins.plugins.advisor.casc;
+
+import com.cloudbees.jenkins.plugins.advisor.AdvisorGlobalConfiguration;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class AdvisorJCasCompatibilityTest extends RoundTripAbstractTest {
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        AdvisorGlobalConfiguration advisor = AdvisorGlobalConfiguration.getInstance();
+        assertEquals("me@email.com", advisor.getEmail());
+        assertEquals("we@email.com,they@email.com", advisor.getCc());
+        assertTrue(advisor.isAcceptToS());
+        assertTrue(advisor.isNagDisabled());
+        assertEquals(2, advisor.getExcludedComponents().size());
+        assertThat(advisor.getExcludedComponents().toArray(), arrayContainingInAnyOrder(Arrays.asList("ThreadDumps", "PipelineThreadDump").toArray()));
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "excludedComponents = [ThreadDumps, PipelineThreadDump]";
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfiguratorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfiguratorTest.java
@@ -38,7 +38,7 @@ public class AdvisorRootConfiguratorTest {
     @ClassRule
     public static JenkinsRule rule = new JenkinsRule();
     @Rule
-    public ExpectedException thrown= ExpectedException.none();
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setUpConfigurator() {

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfiguratorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfiguratorTest.java
@@ -1,0 +1,319 @@
+package com.cloudbees.jenkins.plugins.advisor.casc;
+
+import com.cloudbees.jenkins.plugins.advisor.AdvisorGlobalConfiguration;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import io.jenkins.plugins.casc.model.Scalar;
+import io.jenkins.plugins.casc.model.Sequence;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class AdvisorRootConfiguratorTest {
+
+    private final static String FAKE_EMAIL = "fake@email.com";
+    private final static String FAKE_CC = "onemore@mail.com,another@email.com";
+    private final static Set<String> EXCLUDED = new HashSet<>(Arrays.asList("ThreadDumps", "PipelineThreadDump"));
+    private final static Boolean ACCEPT_TOS = Boolean.TRUE;
+    private final static Boolean NAG_DISABLED = Boolean.TRUE;
+
+    private AdvisorRootConfigurator configurator;
+    private AdvisorGlobalConfiguration configuration;
+    private Mapping mapping;
+    private ConfigurationContext context;
+
+    @ClassRule
+    public static JenkinsRule rule = new JenkinsRule();
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
+
+    @Before
+    public void setUpConfigurator() {
+        context = new ConfigurationContext(ConfiguratorRegistry.get());
+        configurator = new AdvisorRootConfigurator();
+
+        configuration = new AdvisorGlobalConfiguration(FAKE_EMAIL, FAKE_CC, EXCLUDED);
+        configuration.setAcceptToS(ACCEPT_TOS);
+        configuration.setNagDisabled(NAG_DISABLED);
+
+        mapping = new Mapping();
+        mapping.put("acceptToS", ACCEPT_TOS);
+        mapping.put("cc", FAKE_CC);
+        mapping.put("email", FAKE_EMAIL);
+        mapping.put("nagDisabled", NAG_DISABLED);
+        Sequence s = new Sequence();
+        s.add(new Scalar("ThreadDumps"));
+        s.add(new Scalar("PipelineThreadDump"));
+        mapping.putIfNotEmpry("excludedComponents", s);
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals("advisor", configurator.getName());
+    }
+
+    @Test
+    public void testGetTarget() {
+        assertEquals("Wrong target class", configurator.getTarget(), AdvisorGlobalConfiguration.class);
+    }
+
+    @Test
+    public void testCanConfigure() {
+        assertTrue("Can't configure AdvisorGlobalConfiguration", configurator.canConfigure(AdvisorGlobalConfiguration.class));
+        assertFalse("Can configure AdvisorRootConfigurator", configurator.canConfigure(AdvisorRootConfigurator.class));
+    }
+
+    @Test
+    public void testGetImplementedAPI() {
+        assertEquals("Wrong implemented API", configurator.getImplementedAPI(), AdvisorGlobalConfiguration.class);
+    }
+
+    @Test
+    public void testGetConfigurators() {
+        assertThat(configurator.getConfigurators(context), contains(configurator));
+    }
+
+    @Test
+    public void testDescribe() throws Exception {
+        Mapping described = configurator.describe(configuration, context).asMapping();
+        assertEquals(mapping.getScalarValue("email"), described.getScalarValue("email"));
+        assertEquals(mapping.getScalarValue("cc"), described.getScalarValue("cc"));
+        assertEquals(mapping.getScalarValue("acceptToS"), described.getScalarValue("acceptToS"));
+        assertEquals(mapping.getScalarValue("nagDisabled"), described.getScalarValue("nagDisabled"));
+        Set<String> mappingSeq = toScalarValues(mapping.get("excludedComponents").asSequence());
+        Set<String> describedSeq = toScalarValues(described.get("excludedComponents").asSequence());
+        assertEquals(mappingSeq.size(), describedSeq.size());
+        assertThat(describedSeq.toArray(), arrayContainingInAnyOrder(mappingSeq.toArray()));
+    }
+
+    @Test
+    public void testDescribeWithEmptyEmail() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration("", FAKE_CC, EXCLUDED);
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertTrue(described.isEmpty());
+    }
+
+    @Test
+    public void testDescribeWithNullEmail() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration(null, FAKE_CC, EXCLUDED);
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertTrue(described.isEmpty());
+    }
+
+    @Test
+    public void testDescribeWithBlankEmail() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration(" ", FAKE_CC, EXCLUDED);
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertTrue(described.isEmpty());
+    }
+
+    @Test
+    public void testDescribeWithEmptyCC() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration(FAKE_EMAIL, "", EXCLUDED);
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertEquals(mapping.getScalarValue("email"), described.getScalarValue("email"));
+        assertNull(described.get("cc"));
+        assertEquals(mapping.getScalarValue("acceptToS"), described.getScalarValue("acceptToS"));
+        assertEquals(mapping.getScalarValue("nagDisabled"), described.getScalarValue("nagDisabled"));
+        Set<String> mappingSeq = toScalarValues(mapping.get("excludedComponents").asSequence());
+        Set<String> describedSeq = toScalarValues(described.get("excludedComponents").asSequence());
+        assertEquals(mappingSeq.size(), describedSeq.size());
+        assertThat(describedSeq.toArray(), arrayContainingInAnyOrder(mappingSeq.toArray()));
+    }
+
+    @Test
+    public void testDescribeWithNullCC() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration(FAKE_EMAIL, null, EXCLUDED);
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertEquals(mapping.getScalarValue("email"), described.getScalarValue("email"));
+        assertNull(described.get("cc"));
+        assertEquals(mapping.getScalarValue("acceptToS"), described.getScalarValue("acceptToS"));
+        assertEquals(mapping.getScalarValue("nagDisabled"), described.getScalarValue("nagDisabled"));
+        Set<String> mappingSeq = toScalarValues(mapping.get("excludedComponents").asSequence());
+        Set<String> describedSeq = toScalarValues(described.get("excludedComponents").asSequence());
+        assertEquals(mappingSeq.size(), describedSeq.size());
+        assertThat(describedSeq.toArray(), arrayContainingInAnyOrder(mappingSeq.toArray()));
+    }
+
+    @Test
+    public void testDescribeWithBlankCC() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration(FAKE_EMAIL, " ", EXCLUDED);
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertEquals(mapping.getScalarValue("email"), described.getScalarValue("email"));
+        assertNull(described.get("cc"));
+        assertEquals(mapping.getScalarValue("acceptToS"), described.getScalarValue("acceptToS"));
+        assertEquals(mapping.getScalarValue("nagDisabled"), described.getScalarValue("nagDisabled"));
+        Set<String> mappingSeq = toScalarValues(mapping.get("excludedComponents").asSequence());
+        Set<String> describedSeq = toScalarValues(described.get("excludedComponents").asSequence());
+        assertEquals(mappingSeq.size(), describedSeq.size());
+        assertThat(describedSeq.toArray(), arrayContainingInAnyOrder(mappingSeq.toArray()));
+    }
+
+    @Test
+    public void testDescribeWithNullExcluded() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration(FAKE_EMAIL, FAKE_CC, null);
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertEquals(mapping.getScalarValue("email"), described.getScalarValue("email"));
+        assertEquals(mapping.getScalarValue("cc"), described.getScalarValue("cc"));
+        assertEquals(mapping.getScalarValue("acceptToS"), described.getScalarValue("acceptToS"));
+        assertEquals(mapping.getScalarValue("nagDisabled"), described.getScalarValue("nagDisabled"));
+        Set<String> describedSeq = toScalarValues(described.get("excludedComponents").asSequence());
+        assertEquals(1, describedSeq.size());
+        assertEquals(AdvisorGlobalConfiguration.SEND_ALL_COMPONENTS, describedSeq.toArray()[0]);
+    }
+
+    @Test
+    public void testDescribeWithEmptyExcluded() throws Exception {
+        final AdvisorGlobalConfiguration c = new AdvisorGlobalConfiguration(FAKE_EMAIL, FAKE_CC, new HashSet<>());
+        c.setAcceptToS(ACCEPT_TOS);
+        c.setNagDisabled(NAG_DISABLED);
+
+        Mapping described = configurator.describe(c, context).asMapping();
+        assertEquals(mapping.getScalarValue("email"), described.getScalarValue("email"));
+        assertEquals(mapping.getScalarValue("cc"), described.getScalarValue("cc"));
+        assertEquals(mapping.getScalarValue("acceptToS"), described.getScalarValue("acceptToS"));
+        assertEquals(mapping.getScalarValue("nagDisabled"), described.getScalarValue("nagDisabled"));
+        Set<String> describedSeq = toScalarValues(described.get("excludedComponents").asSequence());
+        assertEquals(1, describedSeq.size());
+        assertEquals(AdvisorGlobalConfiguration.SEND_ALL_COMPONENTS, describedSeq.toArray()[0]);
+    }
+
+    private Set<String> toScalarValues(Sequence s) throws Exception {
+        Set<String> converted = new HashSet<>(s.size());
+        for (CNode cNode : s) {
+            converted.add(cNode.asScalar().getValue());
+        }
+        return converted;
+    }
+
+    @Test
+    public void testInstance() throws Exception {
+        AdvisorGlobalConfiguration instance = configurator.instance(mapping, context);
+        assertEquals(configuration.getEmail(), instance.getEmail());
+        assertEquals(configuration.getCc(), instance.getCc());
+        assertEquals(configuration.isAcceptToS(), instance.isAcceptToS());
+        assertEquals(configuration.isNagDisabled(), instance.isNagDisabled());
+        assertEquals(configuration.getExcludedComponents().size(), instance.getExcludedComponents().size());
+        assertThat(instance.getExcludedComponents().toArray(), arrayContainingInAnyOrder(configuration.getExcludedComponents().toArray()));
+        assertTrue(instance.isValid());
+    }
+
+    @Test
+    public void testInstanceSENDALL() throws Exception {
+        final Mapping mappingWithDefault = new Mapping();
+        mappingWithDefault.put("cc", FAKE_CC);
+        mappingWithDefault.put("email", FAKE_EMAIL);
+        mappingWithDefault.put("acceptToS", ACCEPT_TOS);
+
+        AdvisorGlobalConfiguration instance = configurator.instance(mappingWithDefault, context);
+        assertTrue(instance.isAcceptToS());
+        assertFalse(instance.isNagDisabled());
+        assertEquals(1, instance.getExcludedComponents().size());
+        assertEquals(AdvisorGlobalConfiguration.SEND_ALL_COMPONENTS, instance.getExcludedComponents().toArray()[0]);
+        assertTrue(instance.isValid());
+    }
+
+    @Test
+    public void testInstanceWithOutToS() throws Exception {
+        thrown.expect(ConfiguratorException.class);
+        final Mapping mappingWithDefault = new Mapping();
+        mappingWithDefault.put("cc", FAKE_CC);
+        mappingWithDefault.put("email", FAKE_EMAIL);
+
+        configurator.instance(mappingWithDefault, context);
+    }
+
+    @Test
+    public void testInstanceNotAcceptedToS() throws Exception {
+        thrown.expect(ConfiguratorException.class);
+        final Mapping mappingNotAcceptingToS = new Mapping();
+        mappingNotAcceptingToS.put("acceptToS", false);
+        mappingNotAcceptingToS.put("cc", FAKE_CC);
+        mappingNotAcceptingToS.put("email", FAKE_EMAIL);
+        mappingNotAcceptingToS.put("nagDisabled", NAG_DISABLED);
+
+        configurator.instance(mappingNotAcceptingToS, context);
+    }
+
+    @Test
+    public void testInstanceEmptyEmail() throws Exception {
+        thrown.expect(ConfiguratorException.class);
+        final Mapping m = new Mapping();
+        m.put("acceptToS", ACCEPT_TOS);
+        m.put("cc", FAKE_CC);
+        m.put("email", "");
+        m.put("nagDisabled", NAG_DISABLED);
+
+        configurator.instance(m, context);
+    }
+
+    @Test
+    public void testInstanceBadEmail() throws Exception {
+        thrown.expect(ConfiguratorException.class);
+        final Mapping m = new Mapping();
+        m.put("acceptToS", ACCEPT_TOS);
+        m.put("cc", FAKE_CC);
+        m.put("email", "bad_email");
+        m.put("nagDisabled", NAG_DISABLED);
+
+        configurator.instance(m, context);
+    }
+
+    @Test
+    public void testInstanceEmptyCC() throws Exception {
+        thrown.expect(ConfiguratorException.class);
+        final Mapping m = new Mapping();
+        m.put("acceptToS", false);
+        m.put("cc", "");
+        m.put("email", FAKE_EMAIL);
+        m.put("nagDisabled", NAG_DISABLED);
+
+        configurator.instance(m, context);
+    }
+
+    @Test
+    public void testInstanceBadCC() throws Exception {
+        thrown.expect(ConfiguratorException.class);
+        final Mapping m = new Mapping();
+        m.put("acceptToS", false);
+        m.put("cc", "bad_cc");
+        m.put("email", FAKE_EMAIL);
+        m.put("nagDisabled", NAG_DISABLED);
+
+        configurator.instance(m, context);
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/advisor/casc/configuration-as-code.yaml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/advisor/casc/configuration-as-code.yaml
@@ -1,0 +1,8 @@
+advisor:
+  acceptToS: true
+  cc: "we@email.com,they@email.com"
+  email: "me@email.com"
+  excludedComponents:
+    - "ThreadDumps"
+    - "PipelineThreadDump"
+  nagDisabled: true


### PR DESCRIPTION
See [JENKINS-59695](https://issues.jenkins-ci.org/browse/JENKINS-59695)

This PR intends to make the plugin compatible with JCasC:
- Export configuration
- Import configuration
- Tests to keep checking the compatibility

To export the configuration, the PR adds a new Root configurator, which will generate an export section in yaml file like the following:

```
advisor:
  acceptToS: true
  cc: "we@email.com,they@email.com"
  email: "me@email.com"
  excludedComponents:
    - "ThreadDumps"
    - "PipelineThreadDump"
  nagDisabled: true
```

@alecharp @MRamonLeon @rsandell @varyvol
@aheritier as maintainer
@casz @timja since it's related to CasC