### PR TITLE
[task] Use a dynamic port for WireMock to simulate calls to Advisor server

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfigurationTest.java
@@ -30,6 +30,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -49,16 +50,18 @@ public class AdvisorGlobalConfigurationTest {
   public JenkinsRule j = new JenkinsRule();
 
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig());
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   private AdvisorGlobalConfiguration advisor;
   private final String email = "test@cloudbees.com";
   private final String cc = "";
 
-
   @Before
   public void setup() {
     advisor = AdvisorGlobalConfiguration.getInstance();
+    // Dynamically configure the Advisor Server URL to reach WireMock server
+    System.setProperty("com.cloudbees.jenkins.plugins.advisor.client.AdvisorClientConfig.advisorURL",
+            wireMockRule.url("/"));
   }
 
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitorTest.java
@@ -2,6 +2,7 @@ package com.cloudbees.jenkins.plugins.advisor;
 
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -22,10 +23,17 @@ public class BundleUploadMonitorTest {
   @Rule
   public JenkinsRule j = new JenkinsRule();
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig());
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   private static final String TEST_EMAIL = "test";
   private final String textPrefix = "Jenkins Health Advisor by CloudBees failed to upload a bundle";
+
+  @Before
+  public void setup() {
+    // Dynamically configure the Advisor Server URL to reach WireMock server
+    System.setProperty("com.cloudbees.jenkins.plugins.advisor.client.AdvisorClientConfig.advisorURL",
+            wireMockRule.url("/"));
+  }
 
   @Test
   public void testBundleUploadSuccess() throws Exception {

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
@@ -43,11 +43,14 @@ public class BundleUploadTest {
   @Rule
   public JenkinsRule j = new JenkinsRule();
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig());
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
-  public void resetWireMock() {
+  public void setup() {
     wireMockRule.resetAll();
+    // Dynamically configure the Advisor Server URL to reach WireMock server
+    System.setProperty("com.cloudbees.jenkins.plugins.advisor.client.AdvisorClientConfig.advisorURL",
+            wireMockRule.url("/"));
   }
 
   @WithTimeout(30)

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientTest.java
@@ -5,6 +5,7 @@ import com.cloudbees.jenkins.plugins.advisor.client.model.ClientResponse;
 import com.cloudbees.jenkins.plugins.advisor.client.model.ClientUploadRequest;
 import com.cloudbees.jenkins.plugins.advisor.utils.EmailUtil;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -31,7 +32,14 @@ public class AdvisorClientTest {
   private final AdvisorClient subject = new AdvisorClient(accountCredentials);
 
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig());
+  public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+  @Before
+  public void setup() {
+    // Dynamically configure the Advisor Server URL to reach WireMock server
+    System.setProperty("com.cloudbees.jenkins.plugins.advisor.client.AdvisorClientConfig.advisorURL",
+            wireMockRule.url("/"));
+  }
 
   @Test
   public void testDoCheckHealth() throws Exception {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientConfig.properties
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientConfig.properties
@@ -1,3 +1,2 @@
-com.cloudbees.jenkins.plugins.advisor.client.AdvisorClientConfig.advisorURL=http://localhost:8080
 com.cloudbees.jenkins.plugins.advisor.client.AdvisorClientConfig.advisorUploadTimeoutMinutes=60
 com.cloudbees.jenkins.plugins.advisor.client.AdvisorClientConfig.advisorUploadIdleTimeoutMinutes=60


### PR DESCRIPTION
It took me few minutes to understand why all these tests were failing ... while I had a local Jenkins instance running