### PR TITLE
[JENKINS-59696] [fix] Mark extensions as dynamic loadable to allow the plugin to be used without restarting Jenkins

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfiguration.java
@@ -21,6 +21,7 @@ import hudson.model.ManagementLink;
 import hudson.model.Saveable;
 import hudson.model.listeners.SaveableListener;
 import hudson.util.FormValidation;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import jenkins.util.io.OnMaster;
 import net.sf.json.JSONObject;
@@ -47,7 +48,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class AdvisorGlobalConfiguration
   extends ManagementLink
   implements Describable<AdvisorGlobalConfiguration>, ExtensionPoint, Saveable, OnMaster {
@@ -278,7 +279,7 @@ public class AdvisorGlobalConfiguration
   }
 
   @SuppressWarnings("unused")
-  @Extension
+  @Extension(dynamicLoadable = YesNoMaybe.YES)
   public static final class DescriptorImpl extends Descriptor<AdvisorGlobalConfiguration> {
 
     public DescriptorImpl() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
@@ -11,6 +11,7 @@ import hudson.model.AsyncPeriodicWork;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.jenkinsci.Symbol;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 @Symbol("bundleUpload")
 public class BundleUpload extends AsyncPeriodicWork {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitor.java
@@ -2,6 +2,7 @@ package com.cloudbees.jenkins.plugins.advisor;
 
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
+import jenkins.YesNoMaybe;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.HttpResponse;
@@ -14,7 +15,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * This message will match any of the error messages in the log file.
  */
 @SuppressWarnings("unused")
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class BundleUploadMonitor extends AdministrativeMonitor {
 
   @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
@@ -2,6 +2,7 @@ package com.cloudbees.jenkins.plugins.advisor;
 
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
+import jenkins.YesNoMaybe;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -13,7 +14,7 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
 /**
  * Displays the reminder that the configuration must be done.
  */
-@Extension
+@Extension(dynamicLoadable = YesNoMaybe.YES)
 public class Reminder extends AdministrativeMonitor {
 
   @Override


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-59696

But it seems to not help.

I don't understand for now