### PR TITLE
Remove "plugin" from name tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/cloudbees-jenkins-advisor-plugin/master/src/main/webapp/icons/advisor.svg</hpi.pluginLogoUrl>
   </properties>
 
-  <name>Jenkins Health Advisor by CloudBees Plugin</name>
+  <name>Jenkins Health Advisor by CloudBees</name>
   <description>Get daily reports on security, performance, and/or stability issues found in your Jenkins master by connecting to CloudBees.</description>
   <url>https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin</url>
 


### PR DESCRIPTION
Wiki references the name without the "plugin" part and may be confussing