### PR TITLE
[JENKINS-59696] Upgrade support-core 2.62 -> 2.63

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>support-core</artifactId>
-      <version>2.62</version>
+      <version>2.63</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>


### PR DESCRIPTION
This fix ( https://issues.jenkins-ci.org/browse/JENKINS-59696 ) is allowing to install support-core (and thus advisor) dynamically without restarting the Jenkins Master