### PR TITLE
Fix Jackson versions incompatibility introduced by "Bump bom-2.204.x from 11 to 12"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <!-- Versions conflict resolution. -->
+        <!-- support-core and others plugins require org.jenkins-ci.plugins:jackson2-api:2.11.0 -->
+        <!-- io.jenkins.configuration-as-code:test-harness:1.36 requires jackson 2.10.2 -->
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.11.0</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.204.x</artifactId>
         <version>12</version>


### PR DESCRIPTION
I merged jenkinsci/cloudbees-jenkins-advisor-plugin#73 too quickly and missed that it created a build failure because of a dependency conflict.

It creates a dependency issue. 

```
[WARNING] Rule 4: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.fasterxml.jackson.core:jackson-databind:2.10.2 paths to dependency are:
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-io.jenkins.configuration-as-code:test-harness:1.36
    +-com.fasterxml.jackson.core:jackson-databind:2.10.2
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.core:jackson-databind:2.10.2
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0
          +-com.fasterxml.jackson.core:jackson-databind:2.11.0
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.0
          +-com.fasterxml.jackson.core:jackson-databind:2.11.0
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.0
          +-com.fasterxml.jackson.core:jackson-databind:2.11.0
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
          +-com.fasterxml.jackson.core:jackson-databind:2.11.0
, 
Require upper bound dependencies error for com.fasterxml.jackson.core:jackson-core:2.10.2 paths to dependency are:
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-io.jenkins.configuration-as-code:test-harness:1.36
    +-com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.2
      +-com.fasterxml.jackson.core:jackson-core:2.10.2
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.core:jackson-core:2.10.2
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.core:jackson-databind:2.10.2
          +-com.fasterxml.jackson.core:jackson-core:2.11.0
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0
          +-com.fasterxml.jackson.core:jackson-core:2.11.0
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.0
          +-com.fasterxml.jackson.core:jackson-core:2.11.0
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.module:jackson-module-parameter-names:2.11.0
          +-com.fasterxml.jackson.core:jackson-core:2.11.0
and
+-org.jenkins-ci.plugins:cloudbees-jenkins-advisor:3.3.0-SNAPSHOT
  +-org.jenkins-ci.plugins:support-core:2.70
    +-org.jenkins-ci.plugins:metrics:3.1.2.6
      +-org.jenkins-ci.plugins:jackson2-api:2.11.0 (managed) <-- org.jenkins-ci.plugins:jackson2-api:2.5.4
        +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.0
          +-com.fasterxml.jackson.core:jackson-core:2.11.0

```

While all plugins are depending on `org.jenkins-ci.plugins:jackson2-api:2.11.0` (ok with my 2.204.x baseline ) the `io.jenkins.configuration-as-code:test-harness` depends on the 2.10.2 version. It's a test dep but declared directly in my project thus it wins by default. 

Not sure if I am the only one impacted by this issue or if we should find a better fix in the BOM cc @jglick 
