### PR TITLE
[JENKINS-64262] Store temporary bundles in subdirectory + clean them up

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -47,6 +47,17 @@ Overriding with Java System Property:
 -Dcom.cloudbees.jenkins.plugins.advisor.BundleUpload.initialDelayMinutes=60
 ```
 
+### Temporary Bundle Directory
+
+Cannot be overridden at runtime. Requires restart to take effect. Defaults to `$JENKINS_HOME/support/advisor`.
+
+Overriding with Java System Property:
+
+```bash
+-Dcom.cloudbees.jenkins.plugins.advisor.BundleUpload.tempBundleDirectory=/tmp/jenkins/advisor
+```
+
+
 ## Configure Programmatically
 
 ### plugin version < 3.0

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
@@ -10,6 +10,9 @@ import org.jvnet.hudson.test.WithoutJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.jvnet.hudson.test.recipes.WithTimeout;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import static com.cloudbees.jenkins.plugins.advisor.BundleUpload.BUNDLE_SUCCESSFULLY_UPLOADED;
@@ -83,6 +86,8 @@ public class BundleUploadTest {
 
     // Refresh the configuration?
     assertThat(config.getLastBundleResult(), containsString(BUNDLE_SUCCESSFULLY_UPLOADED));
+
+    assertThat(Files.list(Paths.get(BundleUpload.TEMP_BUNDLE_DIRECTORY)).count(), is(equalTo(0L)));
   }
 
   @Test
@@ -98,7 +103,7 @@ public class BundleUploadTest {
   }
 
   @Test
-  public void execute_isNotValid() {
+  public void execute_isNotValid() throws IOException {
     BundleUpload subject = j.getInstance().getExtensionList(BundleUpload.class).get(0);
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
     assertFalse("The configuration must be valid", config.isValid());
@@ -111,7 +116,7 @@ public class BundleUploadTest {
   }
 
   @Test
-  public void execute_noConnection() {
+  public void execute_noConnection() throws IOException {
     BundleUpload subject = j.getInstance().getExtensionList(BundleUpload.class).get(0);
 
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
@@ -122,6 +127,13 @@ public class BundleUploadTest {
     wireMockRule.shutdownServer();
 
     subject.run();
+  }
+
+  @WithoutJenkins
+  @Test
+  public void getTempBundleDirectory() {
+    assertThat(new BundleUpload().getTempBundleDirectory(),
+        is(equalTo(BundleUpload.TEMP_BUNDLE_DIRECTORY)));
   }
 
   @WithoutJenkins


### PR DESCRIPTION
[JENKINS-64262](https://issues.jenkins.io/browse/JENKINS-64262)

* Generate bundles in a subdirectory `$JENKINS_HOME/support/advisor` instead of `$JENKINS_HOME/support` to avoid conflict with Support Core cleanup process.
* Make this configurable via System Property `com.cloudbees.jenkins.plugins.advisor.BundleUpload.tempBundleDirectory`
* Always delete bundle files on failures if it exists
* Cleanup files under the `advisor` subdirectory (in case some are left over and could not be cleaned up in previous runs...) @aheritier this is to avoid having a directory that grows in size because of deletion failures. Though I am not sure if failure to delete files would be frequent. Your call whether this is needed or useless)