### PR TITLE
Refresh plugin for 2022

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'linux', jdk: '11' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.25</version>
+    <version>4.46</version>
     <relativePath />
   </parent>
 
@@ -16,21 +16,20 @@
   <properties>
     <revision>3.3.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <gitHubRepo>jenkinsci/cloudbees-jenkins-advisor-plugin</gitHubRepo>
-    <jenkins.version>2.222.4</jenkins.version>
-    <java.level>8</java.level>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <jenkins.version>2.319.3</jenkins.version>
     <hpi.pluginChangelogUrl>https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/releases</hpi.pluginChangelogUrl>
     <hpi.pluginLogoUrl>https://raw.githubusercontent.com/jenkinsci/cloudbees-jenkins-advisor-plugin/master/src/main/webapp/icons/advisor.svg</hpi.pluginLogoUrl>
   </properties>
 
   <name>Jenkins Health Advisor by CloudBees</name>
   <description>Get daily reports on security, performance, and/or stability issues found in your Jenkins controller by connecting to CloudBees.</description>
-  <url>https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
@@ -53,7 +52,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
@@ -76,8 +75,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>887.vae9c8ac09ff7</version>
+        <artifactId>bom-2.319.x</artifactId>
+        <version>1577.v63609d9cb_5dc</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -89,7 +88,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>support-core</artifactId>
-      <version>2.75</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
@@ -102,29 +100,11 @@
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion> <!-- TODO pending https://github.com/jenkinsci/bom/pull/294 -->
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.27.2</version>
+      <artifactId>wiremock-jre8-standalone</artifactId>
+      <version>2.33.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -132,21 +112,10 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.8</version>
+      <version>2.9.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/AdvisorGlobalConfigurationTest.java
@@ -218,7 +218,7 @@ public class AdvisorGlobalConfigurationTest {
     j.executeOnServer(doConfigure);
     assertThat(advisor.getExcludedComponents().size(), is(25));
     HtmlPage managePage = wc.goTo("cloudbees-jenkins-advisor");
-    assertTrue(managePage.asNormalizedText().contains("unchecked JenkinsLogs"));
+    assertThat(managePage.asNormalizedText(), containsString("unchecked JenkinsLogs"));
     assertTrue(managePage.asNormalizedText().contains("unchecked SlaveLogs"));
 
     String allComponentsSelected =

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitorTest.java
@@ -64,7 +64,7 @@ public class BundleUploadMonitorTest {
 
     WebClient w = j.createWebClient();
     HtmlPage managePage = w.goTo("manage");
-    assertFalse(managePage.asText().contains(textPrefix));
+    assertFalse(managePage.asNormalizedText().contains(textPrefix));
   }
 
   @Test
@@ -97,7 +97,7 @@ public class BundleUploadMonitorTest {
 
     WebClient w = j.createWebClient();
     HtmlPage managePage = w.goTo("manage");
-    String text = managePage.asText();
+    String text = managePage.asNormalizedText();
     assertTrue(text.contains(textPrefix));
   }
 
@@ -107,7 +107,7 @@ public class BundleUploadMonitorTest {
 
     WebClient w = j.createWebClient();
     HtmlPage managePage = w.goTo("manage");
-    assertFalse(managePage.asText().contains("Successfully uploaded a bundle"));
+    assertFalse(managePage.asNormalizedText().contains("Successfully uploaded a bundle"));
   }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
@@ -88,6 +88,9 @@ public class BundleUploadTest {
     assertThat(config.getLastBundleResult(), containsString(BUNDLE_SUCCESSFULLY_UPLOADED));
 
     assertThat(Files.list(Paths.get(BundleUpload.TEMP_BUNDLE_DIRECTORY)).count(), is(equalTo(0L)));
+
+    // wait for the AsyncPeriodicWork in BundleUpload to finish
+    Thread.sleep(1000L);
   }
 
   @Test

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
@@ -90,7 +90,7 @@ public class BundleUploadTest {
     assertThat(Files.list(Paths.get(BundleUpload.TEMP_BUNDLE_DIRECTORY)).count(), is(equalTo(0L)));
 
     // wait for the AsyncPeriodicWork in BundleUpload to finish
-    Thread.sleep(1000L);
+    Thread.sleep(5000L);
   }
 
   @Test

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
@@ -88,9 +88,6 @@ public class BundleUploadTest {
     assertThat(config.getLastBundleResult(), containsString(BUNDLE_SUCCESSFULLY_UPLOADED));
 
     assertThat(Files.list(Paths.get(BundleUpload.TEMP_BUNDLE_DIRECTORY)).count(), is(equalTo(0L)));
-
-    // wait for the AsyncPeriodicWork in BundleUpload to finish
-    Thread.sleep(5000L);
   }
 
   @Test

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class BundleUploadTest {

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/ReminderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/ReminderTest.java
@@ -40,32 +40,32 @@ public class ReminderTest {
     String part = AdvisorGlobalConfiguration.getInstance().getUrlName();
 
     HtmlPage managePage = w.goTo("manage");
-    assertTrue(managePage.asText().contains(blurb));
+    assertTrue(managePage.asNormalizedText().contains(blurb));
 
     // page doesn't show warning
     submitForm(w, part, "test@test.test", false, true);
     managePage = w.goTo("manage");
-    assertFalse(managePage.asText().contains(blurb));
+    assertFalse(managePage.asNormalizedText().contains(blurb));
 
     // page shows warning
     submitForm(w, part, "", false, true);
     managePage = w.goTo("manage");
-    assertTrue(managePage.asText().contains(blurb));
+    assertTrue(managePage.asNormalizedText().contains(blurb));
 
     // page doesn't show warning
     submitForm(w, part, "", true, true);
     managePage = w.goTo("manage");
-    assertFalse(managePage.asText().contains(blurb));
+    assertFalse(managePage.asNormalizedText().contains(blurb));
 
     // page shows warning
     submitForm(w, part, "", false, false);
     managePage = w.goTo("manage");
-    assertTrue(managePage.asText().contains(blurb));
+    assertTrue(managePage.asNormalizedText().contains(blurb));
 
     // page doesn't show warning
     submitForm(w, part, "", true, false);
     managePage = w.goTo("manage");
-    assertFalse(managePage.asText().contains(blurb));
+    assertFalse(managePage.asNormalizedText().contains(blurb));
   }
 
   @Test
@@ -74,7 +74,7 @@ public class ReminderTest {
 
     WebClient w = j.createWebClient();
     HtmlPage managePage = w.goTo("manage");
-    assertFalse(managePage.asText().contains(blurb));
+    assertFalse(managePage.asNormalizedText().contains(blurb));
   }
 
   private void submitForm(WebClient wc, String part, String userEmail, boolean nagOff, boolean acceptTerms) throws Exception {

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorJCasCompatibilityTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorJCasCompatibilityTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class AdvisorJCasCompatibilityTest extends RoundTripAbstractTest {

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfiguratorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/casc/AdvisorRootConfiguratorTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class AdvisorRootConfiguratorTest {

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientConfigTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientConfigTest.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AdvisorClientConfigTest {
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/AdvisorClientTest.java
@@ -23,7 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.lang.String.format;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AdvisorClientTest {
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/PluginHelperTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/client/PluginHelperTest.java
@@ -6,7 +6,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PluginHelperTest {
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/utils/EmailUtilTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/utils/EmailUtilTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EmailUtilTest {
 


### PR DESCRIPTION
Upgrades the plugin to the latest plugin parent POM and BOM. Also upgrades all testing libraries and removes the use of PowerMock for Java 17 supported. Tested with `mvn clean verify` on Java 17.