### PR TITLE
Fix flaky BundleUploadTest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [ platform: 'linux', jdk: '8' ],
+  [ platform: 'windows', jdk: '8' ],
   [ platform: 'linux', jdk: '11' ],
 ])

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
@@ -45,20 +45,13 @@ public class BundleUpload extends AsyncPeriodicWork {
     "Bundle root directory does not exist and could not be created";
   protected static final String BUNDLE_SUCCESSFULLY_UPLOADED = "Bundle uploaded";
   private TaskListener task;
-  private volatile boolean isRunning; // true if the task is currently running.
 
   public BundleUpload() {
     super("Bundle Upload");
   }
 
-  // for testing
-  protected boolean isRunning() {
-      return isRunning;
-  }
-
   @Override
   protected void execute(TaskListener listener) {
-    isRunning = true;
     task = listener;
 
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
@@ -89,7 +82,6 @@ public class BundleUpload extends AsyncPeriodicWork {
     } else {
       log(Level.SEVERE, UNABLE_TO_GENERATE_SUPPORT_BUNDLE);
     }
-    isRunning = false;
   }
 
   private File generateBundle() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUpload.java
@@ -45,13 +45,20 @@ public class BundleUpload extends AsyncPeriodicWork {
     "Bundle root directory does not exist and could not be created";
   protected static final String BUNDLE_SUCCESSFULLY_UPLOADED = "Bundle uploaded";
   private TaskListener task;
+  private volatile boolean isRunning; // true if the task is currently running.
 
   public BundleUpload() {
     super("Bundle Upload");
   }
 
+  // for testing
+  protected boolean isRunning() {
+      return isRunning;
+  }
+
   @Override
   protected void execute(TaskListener listener) {
+    isRunning = true;
     task = listener;
 
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
@@ -82,6 +89,7 @@ public class BundleUpload extends AsyncPeriodicWork {
     } else {
       log(Level.SEVERE, UNABLE_TO_GENERATE_SUPPORT_BUNDLE);
     }
+    isRunning = false;
   }
 
   private File generateBundle() {

--- a/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadTest.java
@@ -73,8 +73,8 @@ public class BundleUploadTest {
 
     subject.run();
 
-    // wait for the AsyncPeriodicWork in BundleUpload to kick off
-    while (wireMockRule.getAllServeEvents().size() < 2) {
+    // wait for the AsyncPeriodicWork in BundleUpload to kick off and complete.
+    while (wireMockRule.getAllServeEvents().size() < 2 || subject.isRunning()) {
       Thread.sleep(1000L);
     }
 


### PR DESCRIPTION
`BundleUploadTest` is flaky and the performance of the windows agents meant they where more likely than not to flake.

However I am observing these flakes in a different CI system running Linux.

this changes the test to call the synchonous `execute(TaskListener)` rather than the asynchronous `run`

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
