### PR TITLE
[JENKINS-71651] Fix administrative monitor buttons

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/Reminder.java
@@ -5,10 +5,12 @@ import hudson.model.AdministrativeMonitor;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
-import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
 
 /**
  * Displays the reminder that the configuration must be done.
@@ -33,15 +35,15 @@ public class Reminder extends AdministrativeMonitor {
 
   @Restricted(NoExternalUse.class)
   @RequirePOST
-  public HttpResponse doAct(@QueryParameter(fixEmpty = true) String yes, @QueryParameter(fixEmpty = true) String no) {
+  public void doAct(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
-    if (yes != null) {
-      return HttpResponses.redirectViaContextPath(config.getUrlName());
-    } else if (no != null) {
+    if (req.hasParameter("yes")) {
+      rsp.sendRedirect(req.getContextPath() + "/manage/" + config.getUrlName());
+    } else if (req.hasParameter("no")) {
       // should never return null if we get here
-      return HttpResponses.redirectViaContextPath(Jenkins.get().getPluginManager().getSearchUrl() + "/installed");
-    } else { //remind later
-      return HttpResponses.forwardToPreviousPage();
+      rsp.sendRedirect(req.getContextPath() + "/" + Jenkins.get().getPluginManager().getSearchUrl() + "/installed");
+    } else {
+      rsp.forwardToPreviousPage(req);
     }
   }
 }


### PR DESCRIPTION
**[JENKINS-71651](https://issues.jenkins.io/browse/JENKINS-71651)**
## Reproduction environment

A fresh install of Jenkins 2.401.2 LTS
Choosing to install no plugins during the wizard
Installing Health Advisor by CloudBees (https://plugins.jenkins.io/cloudbees-jenkins-advisor/) Version 336.v4d00382fe22c

openjdk version "11.0.18" 2023-01-17
OpenJDK Runtime Environment Temurin-11.0.18+10 (build 11.0.18+10)
OpenJDK 64-Bit Server VM Temurin-11.0.18+10 (build 11.0.18+10, mixed mode)

## Issue
When clicking the "Configure Now" or "Uninstall Plugin" buttons in the administrative monitor for Jenkins Health Advisor by CloudBees plugin, the buttons do not redirect you:
![Jul-14-2023 15-12-21](https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/assets/19917557/e6eb7f97-fc2b-47d6-b8cf-09fbd71fb5c5)

## Expected behaviour
Usually these buttons redirect you to:
JENKINS_URL/manage/cloudbees-jenkins-advisor/
JENKINS_URL/pluginManager/installed


## Testing done

After my changes were implemented, I again ran: `mvn hpi:run -Djenkins.version=2.404` and the administrative monitor is working again:
![Jul-14-2023 16-24-27](https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/assets/19917557/cb1160f1-9139-4fc8-ae22-bc42100222b3)

I also ran `mvn clean verify` and all the tests pass still, and took the `target/cloudbees-jenkins-advisor.hpi` and installed it on my Jenkins 2.401.2 LTS instance described in the `Reproduction environment`, and after restarting, the administrative monitor was also working correctly now:
![Jul-14-2023 17-12-07](https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/assets/19917557/7868188a-6f7f-47e6-987e-6c42d3b2cdbd)




### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
