### PR TITLE
[JENKINS-71656] Fix BundleUploadMonitor links

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/advisor/BundleUploadMonitor.java
@@ -4,10 +4,12 @@ import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
-import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
 
 /**
  * Displays a message whenever there is an issue during the bundle upload process.
@@ -35,11 +37,13 @@ public class BundleUploadMonitor extends AdministrativeMonitor {
 
   @Restricted(NoExternalUse.class)
   @RequirePOST
-  public HttpResponse doAct(@QueryParameter(fixEmpty = true) String yes) {
+  public void doAct(StaplerRequest req, StaplerResponse rsp) throws ServletException, IOException {
     AdvisorGlobalConfiguration config = AdvisorGlobalConfiguration.getInstance();
-    return yes != null
-      ? HttpResponses.redirectViaContextPath(config.getUrlName())
-      : HttpResponses.forwardToPreviousPage();
+    if(req.hasParameter("yes")) {
+      rsp.sendRedirect(req.getContextPath() + "/manage/" + config.getUrlName());
+    } else {
+      rsp.forwardToPreviousPage(req);
+    }
   }
 
   /**


### PR DESCRIPTION
[JENKINS-71656](https://issues.jenkins.io/browse/JENKINS-71656) Similar to https://github.com/jenkinsci/cloudbees-jenkins-advisor-plugin/pull/191/ but for the other monitor.

### Testing done

(changed `BundleUploadMonitor#isActivated` to always `return true`)

* Start Jenkins 2.401.1
* Install Jenkins Health Advisor plugin
* Go to Manage Jenkins
* Click "Check Advisor Settings"

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```