### PR TITLE
Revert "chore: Parallelize Tests"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,17 +135,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>1C</forkCount>
-          <parallel>all</parallel>
-          <useUnlimitedThreads>true</useUnlimitedThreads>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Reverts jenkinsci/cloudbees-jenkins-advisor-plugin#192

The PR hard codes the values which are not suitable for all environments - opt into this when it is run,

Rather than making these changes in multiple plugins please change your environment, and/or make a PR to `buildPlugin` that CI uses to build the plugins.

for example this will use 16 threads and surefire is set to use 756MB per fork so 12GB can be needed with this change.